### PR TITLE
Add basic static KPI tracker site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Valoinsight
+
+Simple static site to visualise VALORANT match KPI scores. KPI items are hard-coded and scores can be entered manually or loaded from a CSV file. The page displays the average score of the entered KPIs.
+
+## Usage
+
+Open `index.html` in your browser. Enter scores for each KPI or select a CSV file with the following format:
+
+```
+id,score,notes
+crosshair,80,good crosshair placement
+communication,70,need to call more
+map,90,solid awareness
+```
+
+The average score will update automatically as scores are entered or when the CSV is loaded.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,59 @@
+const kpiItems = [
+  { id: 'crosshair', name: 'Crosshair Placement' },
+  { id: 'communication', name: 'Communication' },
+  { id: 'map', name: 'Map Awareness' },
+];
+
+const container = document.getElementById('kpi-container');
+const averageEl = document.getElementById('average');
+
+kpiItems.forEach(item => {
+  const div = document.createElement('div');
+  div.innerHTML = `
+    <label>${item.name} score: <input type="number" id="${item.id}" min="0" max="100"></label>
+    <label>Notes: <input type="text" id="${item.id}-note"></label>
+  `;
+  container.appendChild(div);
+});
+
+function updateAverage() {
+  let total = 0;
+  let count = 0;
+  kpiItems.forEach(item => {
+    const value = parseFloat(document.getElementById(item.id).value);
+    if (!isNaN(value)) {
+      total += value;
+      count++;
+    }
+  });
+  const average = count ? (total / count).toFixed(2) : 0;
+  averageEl.textContent = average;
+}
+
+kpiItems.forEach(item => {
+  document.getElementById(item.id).addEventListener('input', updateAverage);
+});
+
+document.getElementById('csvFile').addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = function(evt) {
+    const text = evt.target.result.trim();
+    const lines = text.split(/\r?\n/).slice(1); // skip header
+    lines.forEach(line => {
+      const [id, score, note] = line.split(',');
+      const scoreInput = document.getElementById(id);
+      if (scoreInput) {
+        scoreInput.value = score;
+        const noteInput = document.getElementById(`${id}-note`);
+        if (noteInput) {
+          noteInput.value = note || '';
+        }
+      }
+    });
+    updateAverage();
+  };
+  reader.readAsText(file);
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>VALORANT KPI Tracker</title>
+</head>
+<body>
+    <h1>VALORANT KPI Tracker</h1>
+    <input type="file" id="csvFile" accept=".csv" />
+    <div id="kpi-container"></div>
+    <div>
+        <strong>Average score:</strong> <span id="average">0</span>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/sample.csv
+++ b/sample.csv
@@ -1,0 +1,4 @@
+id,score,notes
+crosshair,80,good crosshair placement
+communication,70,need to call more
+map,90,solid awareness


### PR DESCRIPTION
## Summary
- Create `index.html` and `app.js` for a static VALORANT KPI tracker
- Allow score entry via manual fields or CSV upload and compute average score
- Document usage and provide sample CSV

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "const fs=require('fs');const lines=fs.readFileSync('sample.csv','utf-8').trim().split(/\r?\n/).slice(1);const avg=lines.reduce((sum,line)=>sum+Number(line.split(',')[1]),0)/lines.length;console.log('Average',avg.toFixed(2));"`

------
https://chatgpt.com/codex/tasks/task_e_68c3da5fff1883268fb26c1dec787252