### PR TITLE
Add web form for KPI entries

### DIFF
--- a/app.js
+++ b/app.js
@@ -83,17 +83,29 @@ const kpiData = [
     ]
   }
 ];
+// Flatten KPI structure into a simple list of items
+const kpiItems = [];
+kpiData.forEach(section => {
+  if (section.items) kpiItems.push(...section.items);
+  if (section.subsections) {
+    section.subsections.forEach(sub => {
+      if (sub.items) kpiItems.push(...sub.items);
+    });
+  }
+});
 
 const container = document.getElementById('kpi-container');
 const averageEl = document.getElementById('average');
 
+// Build a table row for each KPI item
 kpiItems.forEach(item => {
-  const div = document.createElement('div');
-  div.innerHTML = `
-    <label>${item.name} score: <input type="number" id="${item.id}" min="0" max="100"></label>
-    <label>Notes: <input type="text" id="${item.id}-note"></label>
+  const row = document.createElement('tr');
+  row.innerHTML = `
+    <td>${item.text}</td>
+    <td><input type="number" id="${item.id}" min="0" max="100"></td>
+    <td><input type="text" id="${item.id}-note"></td>
   `;
-  container.appendChild(div);
+  container.appendChild(row);
 });
 
 function updateAverage() {

--- a/index.html
+++ b/index.html
@@ -7,7 +7,14 @@
 <body>
     <h1>VALORANT KPI採点ツール</h1>
     <input type="file" id="csvFile" accept=".csv" />
-    <div id="kpi-container"></div>
+    <form id="kpi-form">
+        <table id="kpi-table">
+            <thead>
+                <tr><th>KPI</th><th>Score</th><th>Notes</th></tr>
+            </thead>
+            <tbody id="kpi-container"></tbody>
+        </table>
+    </form>
     <div>
         <strong>Average score:</strong> <span id="average">0</span>
     </div>


### PR DESCRIPTION
## Summary
- Render KPI items in an interactive table with one row per KPI
- Flatten KPI definitions and wire up average score updates

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ff82cc88832689cf3833a3445966