### PR TITLE
Display average score as sticky footer

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,9 +1,13 @@
 /* Simple and refined styling for VALORANT KPI tool */
+:root {
+  --heading-font-size: clamp(1.5rem, 5vw, 2rem);
+}
+
 body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.6;
   margin: 0;
-  padding: 40px 20px;
+  padding: 0 20px 80px;
   background-color: #f5f7fa;
   color: #333;
 }
@@ -11,7 +15,8 @@ body {
 h1 {
   text-align: center;
   font-weight: 300;
-  margin-bottom: 30px;
+  margin: 20px 0 30px;
+  font-size: var(--heading-font-size);
 }
 
 input[type="file"] {
@@ -31,7 +36,16 @@ input[type="file"] {
 
 
 #average-container {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
   text-align: center;
+  background-color: #fff;
+  padding: 10px 0;
+  border-top: 1px solid #ccc;
+  z-index: 1000;
+  font-size: var(--heading-font-size);
 }
 
 .section-heading {


### PR DESCRIPTION
## Summary
- Move Average score section below main content to display at page bottom
- Style Average score container as fixed footer with responsive h1-sized text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c40968da8c83268987efa38304b3e4