### PR TITLE
除外チェックボックスのレイアウト調整

### DIFF
--- a/app.js
+++ b/app.js
@@ -120,6 +120,7 @@ function addItem(item) {
   const skipLabel = document.createElement('label');
   skipLabel.setAttribute('for', `${item.id}-skip`);
   skipLabel.textContent = '除外';
+  skipLabel.classList.add('skip-label');
   skipContainer.appendChild(skipCheckbox);
   skipContainer.appendChild(skipLabel);
   wrapper.appendChild(skipContainer);

--- a/style.css
+++ b/style.css
@@ -85,9 +85,15 @@ input[type="file"] {
 
 .skip-container {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 4px;
   margin-bottom: 4px;
+  gap: 2px;
+}
+
+.skip-label {
+  font-size: 0.75em;
+  text-align: center;
 }
 
 .star-rating {


### PR DESCRIPTION
## Summary
- 除外チェックボックスのラベルを下部に配置して中央寄せに変更
- 「除外」ラベルの文字サイズを小さく設定

## Testing
- `npm test` *(package.json が存在しないため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e9c08ce0832696c2a102550a4d3f