### PR TITLE
Remove note input from KPI items

### DIFF
--- a/app.js
+++ b/app.js
@@ -141,12 +141,6 @@ function addItem(item) {
   }
   wrapper.appendChild(starContainer);
   skipCheckbox.addEventListener('change', updateAverage);
-
-  const noteInput = document.createElement('input');
-  noteInput.type = 'text';
-  noteInput.id = `${item.id}-note`;
-  wrapper.appendChild(noteInput);
-
   container.appendChild(wrapper);
 }
 
@@ -213,15 +207,11 @@ document.getElementById('csvFile').addEventListener('change', e => {
     const text = evt.target.result.trim();
     const lines = text.split(/\r?\n/).slice(1); // skip header
     lines.forEach(line => {
-      const [id, score, note] = line.split(',');
+      const [id, score] = line.split(',');
       const wrapper = document.getElementById(id);
       if (wrapper) {
         const rating = parseInt(score, 10) / 20;
         setRating(wrapper, rating);
-      }
-      const noteInput = document.getElementById(`${id}-note`);
-      if (noteInput) {
-        noteInput.value = note || '';
       }
     });
     updateAverage();


### PR DESCRIPTION
## Summary
- Remove per-item note textboxes from KPI form builder
- Drop CSV note column handling for these items

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68c4ed93c11883268f4759b4aa421024