### PR TITLE
Remove dividers between subsections

### DIFF
--- a/app.js
+++ b/app.js
@@ -163,10 +163,10 @@ kpiData.forEach(section => {
       if (sub.items) {
         sub.items.forEach(addItem);
       }
-      const subDivider = document.createElement('hr');
-      subDivider.classList.add('divider');
-      container.appendChild(subDivider);
     });
+    const sectionDivider = document.createElement('hr');
+    sectionDivider.classList.add('divider');
+    container.appendChild(sectionDivider);
   } else {
     const sectionDivider = document.createElement('hr');
     sectionDivider.classList.add('divider');


### PR DESCRIPTION
## Summary
- stop rendering horizontal dividers between subsections, keeping section dividers intact

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c4f6498ed48326ba878a5b22410cf5