### PR TITLE
Add summary notes section at bottom

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,6 +89,25 @@ const kpiItems = [];
 const container = document.getElementById('kpi-container');
 const averageEl = document.getElementById('average');
 
+// storage for summary notes
+const summaryNotes = {
+  good: '',
+  bad: '',
+  focus: ''
+};
+
+['good', 'bad', 'focus'].forEach(type => {
+  const el = document.getElementById(`summary-${type}`);
+  if (el) {
+    el.addEventListener('input', e => {
+      summaryNotes[type] = e.target.value;
+    });
+  }
+});
+
+// expose for later export
+window.summaryNotes = summaryNotes;
+
 
 function addItem(item) {
   kpiItems.push(item);

--- a/index.html
+++ b/index.html
@@ -11,6 +11,15 @@
     <form id="kpi-form">
         <div id="kpi-container"></div>
     </form>
+    <div id="summary-container">
+        <h2 class="summary-heading">総括ノート</h2>
+        <label for="summary-good" class="summary-label">良かった点</label>
+        <textarea id="summary-good" class="summary-input"></textarea>
+        <label for="summary-bad" class="summary-label">悪かった点</label>
+        <textarea id="summary-bad" class="summary-input"></textarea>
+        <label for="summary-focus" class="summary-label">重点的に伸ばすべき要素は何でしたか</label>
+        <textarea id="summary-focus" class="summary-input"></textarea>
+    </div>
     <div id="average-container">
         <strong>Average score:</strong> <span id="average">0</span>
     </div>

--- a/style.css
+++ b/style.css
@@ -110,3 +110,34 @@ input[type="file"] {
 .star.selected {
   color: gold;
 }
+
+#summary-container {
+  width: 95%;
+  margin: 40px auto 120px;
+}
+
+.summary-heading {
+  text-align: center;
+  background-color: #e2e8f0;
+  padding: 8px 0;
+  border-radius: 4px;
+  font-size: 1.3rem;
+  font-weight: 500;
+}
+
+.summary-label {
+  display: block;
+  margin-top: 15px;
+  font-weight: 600;
+}
+
+.summary-input {
+  width: 100%;
+  min-height: 60px;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 1em;
+}


### PR DESCRIPTION
## Summary
- add a "総括ノート" area at the bottom with fields for good points, bad points, and focus points
- style the new section differently from the top heading
- store summary note inputs in JavaScript for later export

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f67854788326b2753afbe1a1a7cd