### PR TITLE
feat: add alternating backgrounds for KPI items

### DIFF
--- a/style.css
+++ b/style.css
@@ -69,6 +69,15 @@ input[type="file"] {
   align-items: flex-start;
   gap: 10px;
   margin: 8px 0;
+  padding: 4px 8px;
+}
+
+.kpi-item:nth-of-type(odd) {
+  background-color: #ffffff;
+}
+
+.kpi-item:nth-of-type(even) {
+  background-color: #f2f2f2;
 }
 
 .kpi-text {


### PR DESCRIPTION
## Summary
- make KPI items easier to distinguish by alternating subtle white and gray backgrounds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fb7380ac8326ae88dc77202f4b06