### PR TITLE
feat: add json export button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Valoinsight
 
-Simple static site to visualise VALORANT match KPI scores. KPI items are hard-coded and scores can be entered manually. The page displays the average score of the entered KPIs.
+Simple static site to visualise VALORANT match KPI scores. KPI items are hard-coded and scores can be entered manually. The page displays the average score of the entered KPIs. The evaluation and summary notes can also be exported as a JSON file via the **エクスポート** button in the fixed footer.
 
 ## Usage
 

--- a/app.js
+++ b/app.js
@@ -218,23 +218,50 @@ function setRating(wrapper, rating) {
   });
 }
 
-document.getElementById('csvFile').addEventListener('change', e => {
-  const file = e.target.files[0];
-  if (!file) return;
+const csvInput = document.getElementById('csvFile');
+if (csvInput) {
+  csvInput.addEventListener('change', e => {
+    const file = e.target.files[0];
+    if (!file) return;
 
-  const reader = new FileReader();
-  reader.onload = function(evt) {
-    const text = evt.target.result.trim();
-    const lines = text.split(/\r?\n/).slice(1); // skip header
-    lines.forEach(line => {
-      const [id, score] = line.split(',');
-      const wrapper = document.getElementById(id);
-      if (wrapper) {
-        const rating = parseInt(score, 10) / 20;
-        setRating(wrapper, rating);
-      }
-    });
-    updateAverage();
-  };
-  reader.readAsText(file);
+    const reader = new FileReader();
+    reader.onload = function(evt) {
+      const text = evt.target.result.trim();
+      const lines = text.split(/\r?\n/).slice(1); // skip header
+      lines.forEach(line => {
+        const [id, score] = line.split(',');
+        const wrapper = document.getElementById(id);
+        if (wrapper) {
+          const rating = parseInt(score, 10) / 20;
+          setRating(wrapper, rating);
+        }
+      });
+      updateAverage();
+    };
+    reader.readAsText(file);
+  });
+}
+
+document.getElementById('export-btn').addEventListener('click', () => {
+  const data = kpiItems.map(item => {
+    const skip = document.getElementById(`${item.id}-skip`).checked;
+    const wrapper = document.getElementById(item.id);
+    const rating = parseInt(wrapper.dataset.rating || '0');
+    return {
+      id: item.id,
+      '項目文': item.text,
+      '除外チェック': skip,
+      '点数': rating * 20
+    };
+  });
+  data.push(summaryNotes.good, summaryNotes.bad, summaryNotes.focus);
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'kpi_data.json';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
 });

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     </div>
     <div id="average-container">
         <strong>Average score:</strong> <span id="average">0</span> / 100
+        <button id="export-btn">エクスポート</button>
     </div>
     <script src="app.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -48,6 +48,15 @@ input[type="file"] {
   font-size: var(--heading-font-size);
 }
 
+#export-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 6px 12px;
+  font-size: 1rem;
+}
+
 .section-heading {
   margin-top: 20px;
   text-align: left;


### PR DESCRIPTION
## Summary
- add export button to footer to download KPI scores as JSON
- style footer export button
- document export option in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fb85bf748326931a2a3abf60353d