### PR TITLE
Add JSON import and reposition import control

### DIFF
--- a/app.js
+++ b/app.js
@@ -242,6 +242,50 @@ if (csvInput) {
   });
 }
 
+const importInput = document.getElementById('import-json');
+if (importInput) {
+  importInput.addEventListener('change', e => {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = function(evt) {
+      try {
+        const data = JSON.parse(evt.target.result);
+        if (data.kpiElements) {
+          data.kpiElements.forEach(item => {
+            const wrapper = document.getElementById(item.id);
+            if (wrapper) {
+              const rating = (item.score || 0) / 20;
+              setRating(wrapper, rating);
+              const skipCheckbox = document.getElementById(`${item.id}-skip`);
+              if (skipCheckbox) {
+                skipCheckbox.checked = !!item.skip;
+              }
+            }
+          });
+        }
+        if (data.textnotes) {
+          summaryNotes.good = data.textnotes.wasgood || '';
+          summaryNotes.bad = data.textnotes.wasbad || '';
+          summaryNotes.focus = data.textnotes.important || '';
+          const goodEl = document.getElementById('summary-good');
+          const badEl = document.getElementById('summary-bad');
+          const focusEl = document.getElementById('summary-focus');
+          if (goodEl) goodEl.value = summaryNotes.good;
+          if (badEl) badEl.value = summaryNotes.bad;
+          if (focusEl) focusEl.value = summaryNotes.focus;
+        }
+        updateAverage();
+      } catch (err) {
+        console.error('Failed to parse JSON:', err);
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  });
+}
+
 document.getElementById('export-btn').addEventListener('click', () => {
   const kpiElements = kpiItems.map(item => {
     const skip = document.getElementById(`${item.id}-skip`).checked;

--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
 </head>
 <body>
     <h1>VALORANT KPI採点ツール</h1>
+    <div id="import-container">
+        <input type="file" id="import-json" accept="application/json" style="display: none;">
+        <label for="import-json" id="import-btn">インポート</label>
+    </div>
     <form id="kpi-form">
         <div id="kpi-container"></div>
     </form>

--- a/style.css
+++ b/style.css
@@ -49,12 +49,27 @@ input[type="file"] {
 }
 
 #export-btn {
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  padding: 6px 12px;
-  font-size: 1rem;
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    padding: 6px 12px;
+    font-size: 1rem;
+}
+
+#import-container {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+#import-btn {
+    display: inline-block;
+    padding: 6px 12px;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background-color: #fff;
+    cursor: pointer;
 }
 
 .section-heading {


### PR DESCRIPTION
## Summary
- Add JSON import interface and logic to populate KPI ratings and summary notes
- Move import file selector from footer to directly beneath page title and style it

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c50a54b5b88326aaf989962c8ae541