### PR TITLE
Ensure JSON import processes before resetting input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Valoinsight
 
-Simple static site to visualise VALORANT match KPI scores. KPI items are hard-coded and scores can be entered manually. The page displays the average score of the entered KPIs. The evaluation and summary notes can also be exported as a JSON file via the **エクスポート** button in the fixed footer.
+Simple static site to visualise VALORANT match KPI scores. KPI items are hard-coded and scores can be entered manually. The page displays the average score of the entered KPIs. The evaluation and summary notes can also be exported as a JSON file via the **エクスポート** button in the fixed footer. Previously exported data can be loaded back into the page using the **インポート** button.
 
 ## Usage
 

--- a/app.js
+++ b/app.js
@@ -249,6 +249,7 @@ if (importInput) {
     if (!file) return;
 
     const reader = new FileReader();
+    const inputEl = e.target;
     reader.onload = function(evt) {
       try {
         const data = JSON.parse(evt.target.result);
@@ -279,10 +280,12 @@ if (importInput) {
         updateAverage();
       } catch (err) {
         console.error('Failed to parse JSON:', err);
+      } finally {
+        // reset input value after processing so the same file can be re-imported
+        inputEl.value = '';
       }
     };
     reader.readAsText(file);
-    e.target.value = '';
   });
 }
 


### PR DESCRIPTION
## Summary
- Prevent JSON import from clearing the file input before FileReader finishes reading
- Reset file input only after processing so re-importing the same file works reliably
- Document how to re-import exported data via the インポート button

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c50e73215c8326b7ded18492885c71