### PR TITLE
feat: track attribute averages

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,27 +2,27 @@ const kpiData = [
   {
     heading: '編成中',
     items: [
-      { id: 'remember-vc', text: '誰のVCが無いか覚えてましたか' },
-      { id: 'role-balance', text: 'ロール過不足は認識できましたか', note: ['エントリー/索敵/スモーク/トラップ/フラッシュ'] },
-      { id: 'strategy-axis', text: '編成から立ち回りの軸を見いだせましたか' }
+      { id: 'remember-vc', text: '誰のVCが無いか覚えてましたか', attribute: 'pregame' },
+      { id: 'role-balance', text: 'ロール過不足は認識できましたか', note: ['エントリー/索敵/スモーク/トラップ/フラッシュ'], attribute: 'pregame' },
+      { id: 'strategy-axis', text: '編成から立ち回りの軸を見いだせましたか', attribute: 'pregame' }
     ]
   },
   {
     heading: '1st準備フェーズ',
     items: [
-      { id: 'self-role', text: '自分がロールを全うすべきか/イレギュラー対応すべきか判断できましたか', note: ['・0デュエ2イニシ編成で自分イニシ → 自分がデュエ的な戦う動きをする', '・攻めでサイファーが逆サイト管理してくれそう → デフォルト戦術', '・イニシがデュエにくっついてアビリティ投げそう → ラッシュ可能かも'] },
-      { id: 'ally-counter', text: '必要に応じて適切に: 敵編成に対するアンチ戦術考案と味方への声掛けはできましたか', note: ['・味方が敵の編成から対策を考えられそうか判断する', '・ネオンがワイヤーのある所に行かなそうか、行くとしてもアンチワイヤーを考えていそうか、など'] },
-      { id: 'weird-teammate', text: '味方に変な奴がいる場合: その人との連携プレイの優先度を下げる決意をしましたか', note: ['・名前が「SDGs」「◯◯トロールします」', '・VCで明らかに様子がおかしい'] }
+      { id: 'self-role', text: '自分がロールを全うすべきか/イレギュラー対応すべきか判断できましたか', note: ['・0デュエ2イニシ編成で自分イニシ → 自分がデュエ的な戦う動きをする', '・攻めでサイファーが逆サイト管理してくれそう → デフォルト戦術', '・イニシがデュエにくっついてアビリティ投げそう → ラッシュ可能かも'], attribute: 'pregame' },
+      { id: 'ally-counter', text: '必要に応じて適切に: 敵編成に対するアンチ戦術考案と味方への声掛けはできましたか', note: ['・味方が敵の編成から対策を考えられそうか判断する', '・ネオンがワイヤーのある所に行かなそうか、行くとしてもアンチワイヤーを考えていそうか、など'], attribute: 'pregame' },
+      { id: 'weird-teammate', text: '味方に変な奴がいる場合: その人との連携プレイの優先度を下げる決意をしましたか', note: ['・名前が「SDGs」「◯◯トロールします」', '・VCで明らかに様子がおかしい'], attribute: 'pregame' }
     ]
   },
   {
     heading: '各ラウンドの準備フェーズ',
     items: [
-      { id: 'weapon-econ', text: '敵味方の武器管理を適切に行えましたか', note: ['・味方がハーフで4人買える時に呼びかけ', '・敵がエコかどうか', '・敵にオペレーターが出る可能性があるか'] },
-      { id: 'ult-management', text: '敵味方のアルティメット管理を適切に行えましたか', note: ['・広範囲デバフ系ウルト(KJ, ブリーチ など)によってどう仕掛けるか・仕掛けられるか'] },
-      { id: 'emotion-reset', text: '前ラウンドの感情処理を5秒以内に終わらせましたか', note: ['・残20秒までに次の話を始められないと味方に浸透しない'] },
-      { id: 'counter-plan', text: '前のラウンドの内容をもとに適切に対策を考えられましたか' },
-      { id: 'propose-strat', text: '必要に応じて作戦を提案できましたか' }
+      { id: 'weapon-econ', text: '敵味方の武器管理を適切に行えましたか', note: ['・味方がハーフで4人買える時に呼びかけ', '・敵がエコかどうか', '・敵にオペレーターが出る可能性があるか'], attribute: 'macro' },
+      { id: 'ult-management', text: '敵味方のアルティメット管理を適切に行えましたか', note: ['・広範囲デバフ系ウルト(KJ, ブリーチ など)によってどう仕掛けるか・仕掛けられるか'], attribute: 'macro' },
+      { id: 'emotion-reset', text: '前ラウンドの感情処理を5秒以内に終わらせましたか', note: ['・残20秒までに次の話を始められないと味方に浸透しない'], attribute: 'macro' },
+      { id: 'counter-plan', text: '前のラウンドの内容をもとに適切に対策を考えられましたか', attribute: 'macro' },
+      { id: 'propose-strat', text: '必要に応じて作戦を提案できましたか', attribute: 'macro' }
     ]
   },
   {
@@ -31,54 +31,54 @@ const kpiData = [
       {
         heading: '撃ち合い',
         items: [
-          { id: 'headline', text: 'ヘッドラインを維持できましたか' },
-          { id: 'angle-advantage', text: '必要に応じて適切にアングル(遠近壁)有利を取れていましたか' },
-          { id: 'off-angle', text: '必要に応じて適切にオフアングルを使えましたか' },
-          { id: 'peeker-adv', text: '必要に応じて適切にピーカーズアドバンテージを取れていましたか' },
-          { id: 'timing-peek', text: '必要に応じて適切にタイミングピークできましたか' },
-          { id: 'slicing-pie', text: '必要に応じて適切にカッティングパイできましたか' },
-          { id: 'cover-angle', text: '味方がカバー射線を通せるアングル&位置の維持はできましたか' },
-          { id: 'magazine', text: 'マガジン残弾数管理は適切でしたか' },
-          { id: 'anti-wallbang', text: 'モク抜きされにくい位置にいましたか' },
-          { id: 'anti-flash', text: 'フラッシュを食らっても生存できる位置にいましたか' },
-          { id: 'variable-peak', text: '体の出し方に緩急をつけられましたか' }
+          { id: 'headline', text: 'ヘッドラインを維持できましたか', attribute: 'physical' },
+          { id: 'angle-advantage', text: '必要に応じて適切にアングル(遠近壁)有利を取れていましたか', attribute: 'physical' },
+          { id: 'off-angle', text: '必要に応じて適切にオフアングルを使えましたか', attribute: 'physical' },
+          { id: 'peeker-adv', text: '必要に応じて適切にピーカーズアドバンテージを取れていましたか', attribute: 'physical' },
+          { id: 'timing-peek', text: '必要に応じて適切にタイミングピークできましたか', attribute: 'physical' },
+          { id: 'slicing-pie', text: '必要に応じて適切にカッティングパイできましたか', attribute: 'physical' },
+          { id: 'cover-angle', text: '味方がカバー射線を通せるアングル&位置の維持はできましたか', attribute: 'physical' },
+          { id: 'magazine', text: 'マガジン残弾数管理は適切でしたか', attribute: 'physical' },
+          { id: 'anti-wallbang', text: 'モク抜きされにくい位置にいましたか', attribute: 'physical' },
+          { id: 'anti-flash', text: 'フラッシュを食らっても生存できる位置にいましたか', attribute: 'physical' },
+          { id: 'variable-peak', text: '体の出し方に緩急をつけられましたか', attribute: 'physical' }
         ]
       },
       {
         heading: '盤面管理',
         items: [
-          { id: 'engage-decision', text: '接敵していいか判断してからピークしましたか' },
-          { id: 'reposition', text: '必要に応じて適切にポジションを変えましたか' },
-          { id: 'consider-enemy-count', text: 'エントリー時に敵の数と質の両方を考慮しましたか' },
-          { id: 'not-miss-rotate', text: 'ローテートが出来る状況を見落としませんでしたか' },
-          { id: 'rotate-reason', text: 'ローテートする判断の際、適切な根拠はありましたか' },
-          { id: 'ult-change', text: '敵味方のアルティメット状況変化を認識していましたか' },
-          { id: 'silent-steps', text: '必要に応じて適切に足音を消せましたか', note: ['・ラウンド開始直後の情報取り段階', '・ローテート画策中'] },
-          { id: 'push-care', text: 'プッシュケアできましたか' },
-          { id: 'scoreboard-check', text: '可能な時、オーブとプラントの音でスコアボードを確認できましたか' },
-          { id: 'backstab-care', text: '裏取りされうるエリアで適切に警戒できましたか' },
-          { id: 'clearing', text: 'クリアリングミスはありませんでしたか' }
+          { id: 'engage-decision', text: '接敵していいか判断してからピークしましたか', attribute: 'macro' },
+          { id: 'reposition', text: '必要に応じて適切にポジションを変えましたか', attribute: 'macro' },
+          { id: 'consider-enemy-count', text: 'エントリー時に敵の数と質の両方を考慮しましたか', attribute: 'macro' },
+          { id: 'not-miss-rotate', text: 'ローテートが出来る状況を見落としませんでしたか', attribute: 'macro' },
+          { id: 'rotate-reason', text: 'ローテートする判断の際、適切な根拠はありましたか', attribute: 'macro' },
+          { id: 'ult-change', text: '敵味方のアルティメット状況変化を認識していましたか', attribute: 'macro' },
+          { id: 'silent-steps', text: '必要に応じて適切に足音を消せましたか', note: ['・ラウンド開始直後の情報取り段階', '・ローテート画策中'], attribute: 'macro' },
+          { id: 'push-care', text: 'プッシュケアできましたか', attribute: 'macro' },
+          { id: 'scoreboard-check', text: '可能な時、オーブとプラントの音でスコアボードを確認できましたか', attribute: 'macro' },
+          { id: 'backstab-care', text: '裏取りされうるエリアで適切に警戒できましたか', attribute: 'macro' },
+          { id: 'clearing', text: 'クリアリングミスはありませんでしたか', attribute: 'macro' }
         ]
       },
       {
         heading: '連携',
         items: [
-          { id: 'death-call', text: '死亡時に即座に必要なことを報告できましたか' },
-          { id: 'ask-help', text: '自分が困った時に適切に助けを要求しましたか' },
-          { id: 'follow-entry', text: '適切にエントリーに着いていきましたか' },
-          { id: 'support-duelist', text: 'デュエリスト(先頭の人)が困っている時に適切に提案したり、適切に支援アビリティを出せましたか' },
-          { id: 'cover-line', text: '必要に応じて適切に味方へのカバーの射線を通せましたか' },
-          { id: 'safe-melee', text: '近接武器・アビリティは安全な状況でのみ構えていましたか' },
-          { id: 'protect-defuser', text: '解除者の射線に敵が立たないようにできましたか' }
+          { id: 'death-call', text: '死亡時に即座に必要なことを報告できましたか', attribute: 'teamwork' },
+          { id: 'ask-help', text: '自分が困った時に適切に助けを要求しましたか', attribute: 'teamwork' },
+          { id: 'follow-entry', text: '適切にエントリーに着いていきましたか', attribute: 'teamwork' },
+          { id: 'support-duelist', text: 'デュエリスト(先頭の人)が困っている時に適切に提案したり、適切に支援アビリティを出せましたか', attribute: 'teamwork' },
+          { id: 'cover-line', text: '必要に応じて適切に味方へのカバーの射線を通せましたか', attribute: 'teamwork' },
+          { id: 'safe-melee', text: '近接武器・アビリティは安全な状況でのみ構えていましたか', attribute: 'teamwork' },
+          { id: 'protect-defuser', text: '解除者の射線に敵が立たないようにできましたか', attribute: 'teamwork' }
         ]
       },
       {
         heading: 'プラント・ポストプラント',
         items: [
-          { id: 'plant-delay', text: 'どこで遅延行為がしやすいか考えてプラント位置を決めましたか' },
-          { id: 'postplant-position', text: '見方が設置した位置に対して強い位置取りができましたか' },
-          { id: 'ability-awareness', text: '味方と敵の残アビリティを認識できましたか' },
-          { id: 'ally-reaction', text: '味方の動きを見てそれに対応した適切なポジショニングはできましたか' }
+          { id: 'plant-delay', text: 'どこで遅延行為がしやすいか考えてプラント位置を決めましたか', attribute: 'plant' },
+          { id: 'postplant-position', text: '見方が設置した位置に対して強い位置取りができましたか', attribute: 'plant' },
+          { id: 'ability-awareness', text: '味方と敵の残アビリティを認識できましたか', attribute: 'plant' },
+          { id: 'ally-reaction', text: '味方の動きを見てそれに対応した適切なポジショニングはできましたか', attribute: 'plant' }
         ]
       }
     ]
@@ -88,6 +88,7 @@ const kpiData = [
 const kpiItems = [];
 const container = document.getElementById('kpi-container');
 const averageEl = document.getElementById('average');
+const attributeKeys = ['pregame', 'physical', 'macro', 'teamwork', 'plant'];
 
 // storage for summary notes
 const summaryNotes = {
@@ -171,7 +172,7 @@ kpiData.forEach(section => {
   container.appendChild(sectionHeading);
 
   if (section.items) {
-    section.items.forEach(addItem);
+    section.items.forEach(item => addItem(item));
   }
   if (section.subsections) {
     section.subsections.forEach(sub => {
@@ -180,7 +181,7 @@ kpiData.forEach(section => {
       subHeading.textContent = sub.heading;
       container.appendChild(subHeading);
       if (sub.items) {
-        sub.items.forEach(addItem);
+        sub.items.forEach(item => addItem(item));
       }
     });
     const sectionDivider = document.createElement('hr');
@@ -193,22 +194,38 @@ kpiData.forEach(section => {
   }
 });
 
-function updateAverage() {
-  let total = 0;
-  let count = 0;
-  kpiItems.forEach(item => {
-    const skip = document.getElementById(`${item.id}-skip`).checked;
-    if (skip) return;
-    const wrapper = document.getElementById(item.id);
-    const rating = parseInt(wrapper.dataset.rating);
-    if (!isNaN(rating)) {
-      total += rating * 20;
-      count++;
-    }
-  });
-  const average = count ? (total / count).toFixed(2) : 0;
-  averageEl.textContent = average;
-}
+  function updateAverage() {
+    let total = 0;
+    let count = 0;
+    const attrTotals = {};
+    const attrCounts = {};
+    attributeKeys.forEach(key => {
+      attrTotals[key] = 0;
+      attrCounts[key] = 0;
+    });
+
+    kpiItems.forEach(item => {
+      const skip = document.getElementById(`${item.id}-skip`).checked;
+      if (skip) return;
+      const wrapper = document.getElementById(item.id);
+      const rating = parseInt(wrapper.dataset.rating);
+      if (!isNaN(rating)) {
+        const score = rating * 20;
+        total += score;
+        count++;
+        attrTotals[item.attribute] += score;
+        attrCounts[item.attribute] += 1;
+      }
+    });
+
+    const average = count ? (total / count).toFixed(2) : 0;
+    averageEl.textContent = average;
+    attributeKeys.forEach(key => {
+      const avg = attrCounts[key] ? (attrTotals[key] / attrCounts[key]).toFixed(2) : 0;
+      const span = document.getElementById(`avg-${key}`);
+      if (span) span.textContent = avg;
+    });
+  }
 
 function setRating(wrapper, rating) {
   wrapper.dataset.rating = rating;
@@ -297,6 +314,7 @@ document.getElementById('export-btn').addEventListener('click', () => {
     return {
       id: item.id,
       text: item.text,
+      attribute: item.attribute,
       skip: skip,
       score: rating * 20
     };

--- a/index.html
+++ b/index.html
@@ -25,7 +25,14 @@
         <textarea id="summary-focus" class="summary-input"></textarea>
     </div>
     <div id="average-container">
-        <strong>Average score:</strong> <span id="average">0</span> / 100
+        <div id="overall-average"><strong>Average score:</strong> <span id="average">0</span> / 100</div>
+        <div id="attribute-averages">
+            <span class="attribute-average">プレゲーム: <span id="avg-pregame">0</span></span>
+            <span class="attribute-average">フィジカル: <span id="avg-physical">0</span></span>
+            <span class="attribute-average">マクロ: <span id="avg-macro">0</span></span>
+            <span class="attribute-average">連携: <span id="avg-teamwork">0</span></span>
+            <span class="attribute-average">プラント: <span id="avg-plant">0</span></span>
+        </div>
         <button id="export-btn">エクスポート</button>
     </div>
     <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -48,6 +48,19 @@ input[type="file"] {
   font-size: var(--heading-font-size);
 }
 
+#attribute-averages {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 1rem;
+  margin-top: 4px;
+}
+
+.attribute-average {
+  white-space: nowrap;
+}
+
 #export-btn {
     position: absolute;
     right: 10px;


### PR DESCRIPTION
## Summary
- add 5 attribute averages in footer
- assign attributes directly on each KPI item for per-attribute scores

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c51695834883269ee18048a8518a0c