### PR TITLE
Add radar chart to footer

### DIFF
--- a/app.js
+++ b/app.js
@@ -90,6 +90,9 @@ const container = document.getElementById('kpi-container');
 const averageEl = document.getElementById('average');
 const attributeKeys = ['pregame', 'physical', 'macro', 'teamwork', 'plant'];
 
+const radarCanvas = document.getElementById('radar-chart');
+const radarCtx = radarCanvas ? radarCanvas.getContext('2d') : null;
+
 // storage for summary notes
 const summaryNotes = {
   good: '',
@@ -109,6 +112,52 @@ const summaryNotes = {
 // expose for later export
 window.summaryNotes = summaryNotes;
 
+
+function drawRadarChart(values) {
+  if (!radarCtx) return;
+  const ctx = radarCtx;
+  const canvas = radarCanvas;
+  const count = values.length;
+  const maxVal = 100;
+  const centerX = canvas.width / 2;
+  const centerY = canvas.height / 2;
+  const radius = Math.min(centerX, centerY) - 10;
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const angleStep = (Math.PI * 2) / count;
+
+  ctx.strokeStyle = '#ccc';
+  for (let i = 0; i < count; i++) {
+    const angle = -Math.PI / 2 + i * angleStep;
+    const x = centerX + radius * Math.cos(angle);
+    const y = centerY + radius * Math.sin(angle);
+    ctx.beginPath();
+    ctx.moveTo(centerX, centerY);
+    ctx.lineTo(x, y);
+    ctx.stroke();
+  }
+
+  ctx.beginPath();
+  for (let i = 0; i < count; i++) {
+    const angle = -Math.PI / 2 + i * angleStep;
+    const r = (values[i] / maxVal) * radius;
+    const x = centerX + r * Math.cos(angle);
+    const y = centerY + r * Math.sin(angle);
+    if (i === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  }
+  ctx.closePath();
+  ctx.fillStyle = 'rgba(255, 99, 132, 0.3)';
+  ctx.strokeStyle = '#ff6384';
+  ctx.stroke();
+  ctx.fill();
+}
+
+drawRadarChart(new Array(attributeKeys.length).fill(0));
 
 function addItem(item) {
   kpiItems.push(item);
@@ -225,6 +274,8 @@ kpiData.forEach(section => {
       const span = document.getElementById(`avg-${key}`);
       if (span) span.textContent = avg;
     });
+    const chartValues = attributeKeys.map(key => attrCounts[key] ? (attrTotals[key] / attrCounts[key]) : 0);
+    drawRadarChart(chartValues);
   }
 
 function setRating(wrapper, rating) {

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
         <textarea id="summary-focus" class="summary-input"></textarea>
     </div>
     <div id="average-container">
+        <canvas id="radar-chart" width="150" height="150"></canvas>
         <div id="overall-average"><strong>総合スコア</strong> <span id="average">0</span> / 100</div>
         <div id="attribute-averages">
             <span class="attribute-average">プレゲーム: <span id="avg-pregame">0</span></span>

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.6;
   margin: 0;
-  padding: 0 20px 80px;
+  padding: 0 20px 250px;
   background-color: #f5f7fa;
   color: #333;
 }
@@ -42,10 +42,19 @@ input[type="file"] {
   width: 100%;
   text-align: center;
   background-color: #fff;
-  padding: 10px 0;
+  padding: 10px 0 20px;
   border-top: 1px solid #ccc;
   z-index: 1000;
   font-size: var(--heading-font-size);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+#radar-chart {
+  width: 150px;
+  height: 150px;
+  margin: 8px 0;
 }
 
 #attribute-averages {
@@ -64,8 +73,8 @@ input[type="file"] {
 #export-btn {
     position: absolute;
     right: 10px;
-    top: 50%;
-    transform: translateY(-50%);
+    top: 10px;
+    transform: none;
     padding: 6px 12px;
     font-size: 1rem;
 }


### PR DESCRIPTION
## Summary
- display a radar chart in the fixed footer to visualize average scores of the five attributes
- style footer for chart placement and adjust export button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c51b01e4f48326bc7f5899d7bb8a44