### PR TITLE
Improve radar chart legend and layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,6 +89,13 @@ const kpiItems = [];
 const container = document.getElementById('kpi-container');
 const averageEl = document.getElementById('average');
 const attributeKeys = ['pregame', 'physical', 'macro', 'teamwork', 'plant'];
+const attributeLabels = {
+  pregame: 'プレゲーム',
+  physical: 'フィジカル',
+  macro: 'マクロ',
+  teamwork: 'チームプレイ',
+  plant: 'プラント'
+};
 
 const radarCanvas = document.getElementById('radar-chart');
 const radarCtx = radarCanvas ? radarCanvas.getContext('2d') : null;
@@ -155,6 +162,20 @@ function drawRadarChart(values) {
   ctx.strokeStyle = '#ff6384';
   ctx.stroke();
   ctx.fill();
+
+  ctx.fillStyle = '#000';
+  ctx.font = '12px sans-serif';
+  for (let i = 0; i < count; i++) {
+    const angle = -Math.PI / 2 + i * angleStep;
+    const labelRadius = radius + 20;
+    const x = centerX + labelRadius * Math.cos(angle);
+    const y = centerY + labelRadius * Math.sin(angle);
+    const key = attributeKeys[i];
+    const text = `${attributeLabels[key]} ${Math.round(values[i])}`;
+    ctx.textAlign = x < centerX ? 'right' : 'left';
+    ctx.textBaseline = y < centerY ? 'bottom' : 'top';
+    ctx.fillText(text, x, y);
+  }
 }
 
 drawRadarChart(new Array(attributeKeys.length).fill(0));
@@ -269,11 +290,6 @@ kpiData.forEach(section => {
 
     const average = count ? (total / count).toFixed(2) : 0;
     averageEl.textContent = average;
-    attributeKeys.forEach(key => {
-      const avg = attrCounts[key] ? (attrTotals[key] / attrCounts[key]).toFixed(2) : 0;
-      const span = document.getElementById(`avg-${key}`);
-      if (span) span.textContent = avg;
-    });
     const chartValues = attributeKeys.map(key => attrCounts[key] ? (attrTotals[key] / attrCounts[key]) : 0);
     drawRadarChart(chartValues);
   }

--- a/index.html
+++ b/index.html
@@ -26,14 +26,7 @@
     </div>
     <div id="average-container">
         <canvas id="radar-chart" width="150" height="150"></canvas>
-        <div id="overall-average"><strong>総合スコア</strong> <span id="average">0</span> / 100</div>
-        <div id="attribute-averages">
-            <span class="attribute-average">プレゲーム: <span id="avg-pregame">0</span></span>
-            <span class="attribute-average">フィジカル: <span id="avg-physical">0</span></span>
-            <span class="attribute-average">マクロ: <span id="avg-macro">0</span></span>
-            <span class="attribute-average">チームプレイ: <span id="avg-teamwork">0</span></span>
-            <span class="attribute-average">プラント: <span id="avg-plant">0</span></span>
-        </div>
+        <div id="overall-average">総合スコア <span id="average">0</span> / 100</div>
         <button id="export-btn">エクスポート</button>
     </div>
     <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -57,23 +57,10 @@ input[type="file"] {
   margin: 8px 0;
 }
 
-#attribute-averages {
-  display: flex;
-  justify-content: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  font-size: 1rem;
-  margin-top: 4px;
-}
-
-.attribute-average {
-  white-space: nowrap;
-}
-
 #export-btn {
     position: absolute;
     right: 10px;
-    top: 10px;
+    bottom: 10px;
     transform: none;
     padding: 6px 12px;
     font-size: 1rem;


### PR DESCRIPTION
## Summary
- remove per-attribute average text from footer and display overall score plainly
- show attribute names with rounded scores at radar chart vertices
- move export button to the bottom-right of the fixed footer

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c51d3512508326a36cef01fb538140