### PR TITLE
Arrange radar chart and scores in footer

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,13 +89,6 @@ const kpiItems = [];
 const container = document.getElementById('kpi-container');
 const averageEl = document.getElementById('average');
 const attributeKeys = ['pregame', 'physical', 'macro', 'teamwork', 'plant'];
-const attributeLabels = {
-  pregame: 'プレゲーム',
-  physical: 'フィジカル',
-  macro: 'マクロ',
-  teamwork: 'チームプレイ',
-  plant: 'プラント'
-};
 
 const radarCanvas = document.getElementById('radar-chart');
 const radarCtx = radarCanvas ? radarCanvas.getContext('2d') : null;
@@ -162,20 +155,6 @@ function drawRadarChart(values) {
   ctx.strokeStyle = '#ff6384';
   ctx.stroke();
   ctx.fill();
-
-  ctx.fillStyle = '#000';
-  ctx.font = '12px sans-serif';
-  for (let i = 0; i < count; i++) {
-    const angle = -Math.PI / 2 + i * angleStep;
-    const labelRadius = radius + 20;
-    const x = centerX + labelRadius * Math.cos(angle);
-    const y = centerY + labelRadius * Math.sin(angle);
-    const key = attributeKeys[i];
-    const text = `${attributeLabels[key]} ${Math.round(values[i])}`;
-    ctx.textAlign = x < centerX ? 'right' : 'left';
-    ctx.textBaseline = y < centerY ? 'bottom' : 'top';
-    ctx.fillText(text, x, y);
-  }
 }
 
 drawRadarChart(new Array(attributeKeys.length).fill(0));
@@ -290,6 +269,11 @@ kpiData.forEach(section => {
 
     const average = count ? (total / count).toFixed(2) : 0;
     averageEl.textContent = average;
+    attributeKeys.forEach(key => {
+      const avg = attrCounts[key] ? (attrTotals[key] / attrCounts[key]).toFixed(2) : 0;
+      const span = document.getElementById(`avg-${key}`);
+      if (span) span.textContent = avg;
+    });
     const chartValues = attributeKeys.map(key => attrCounts[key] ? (attrTotals[key] / attrCounts[key]) : 0);
     drawRadarChart(chartValues);
   }

--- a/index.html
+++ b/index.html
@@ -26,7 +26,16 @@
     </div>
     <div id="average-container">
         <canvas id="radar-chart" width="150" height="150"></canvas>
-        <div id="overall-average">総合スコア <span id="average">0</span> / 100</div>
+        <div id="score-container">
+            <div id="overall-average"><strong>総合スコア</strong> <span id="average">0</span> / 100</div>
+            <div id="attribute-averages">
+                <span class="attribute-average">プレゲーム: <span id="avg-pregame">0</span></span>
+                <span class="attribute-average">フィジカル: <span id="avg-physical">0</span></span>
+                <span class="attribute-average">マクロ: <span id="avg-macro">0</span></span>
+                <span class="attribute-average">チームプレイ: <span id="avg-teamwork">0</span></span>
+                <span class="attribute-average">プラント: <span id="avg-plant">0</span></span>
+            </div>
+        </div>
         <button id="export-btn">エクスポート</button>
     </div>
     <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.6;
   margin: 0;
-  padding: 0 20px 250px;
+  padding: 0 20px 200px;
   background-color: #f5f7fa;
   color: #333;
 }
@@ -40,27 +40,48 @@ input[type="file"] {
   bottom: 0;
   left: 0;
   width: 100%;
-  text-align: center;
   background-color: #fff;
-  padding: 10px 0 20px;
+  padding: 5px 10px;
   border-top: 1px solid #ccc;
   z-index: 1000;
   font-size: var(--heading-font-size);
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
+  justify-content: center;
+  gap: 20px;
 }
 
 #radar-chart {
   width: 150px;
   height: 150px;
-  margin: 8px 0;
+  margin: 0 20px 0 0;
+}
+
+#score-container {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+}
+
+#attribute-averages {
+  display: flex;
+  justify-content: flex-start;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 1rem;
+  margin-top: 4px;
+}
+
+.attribute-average {
+  white-space: nowrap;
 }
 
 #export-btn {
     position: absolute;
     right: 10px;
-    bottom: 10px;
+    top: 10px;
     transform: none;
     padding: 6px 12px;
     font-size: 1rem;


### PR DESCRIPTION
## Summary
- Place radar chart on the left and score details on the right within the fixed footer
- Reduce footer height and adjust layout spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c51fc67d488326ba5eb10a8bfd64ca