### PR TITLE
Move export button to bottom-right

### DIFF
--- a/style.css
+++ b/style.css
@@ -80,8 +80,8 @@ input[type="file"] {
 
 #export-btn {
     position: absolute;
-    right: 10px;
-    top: 10px;
+    right: calc(10px + (100vw - 100%));
+    bottom: 10px;
     transform: none;
     padding: 6px 12px;
     font-size: 1rem;


### PR DESCRIPTION
## Summary
- place export button at bottom-right of the fixed footer
- offset button from scrollbar using calc for responsive spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c522cddc8c8326851c4144a942b654