### PR TITLE
Improve radar chart display

### DIFF
--- a/app.js
+++ b/app.js
@@ -99,6 +99,7 @@ const attributeLabels = {
 
 const radarCanvas = document.getElementById('radar-chart');
 const radarCtx = radarCanvas ? radarCanvas.getContext('2d') : null;
+let currentChartValues = new Array(attributeKeys.length).fill(0);
 
 // storage for summary notes
 const summaryNotes = {
@@ -136,6 +137,7 @@ function drawRadarChart(values) {
 
   ctx.strokeStyle = '#ccc';
   ctx.font = '12px sans-serif';
+  ctx.fillStyle = '#000';
   for (let i = 0; i < count; i++) {
     const angle = -Math.PI / 2 + i * angleStep;
     const x = centerX + radius * Math.cos(angle);
@@ -180,7 +182,20 @@ function drawRadarChart(values) {
   ctx.fill();
 }
 
-drawRadarChart(new Array(attributeKeys.length).fill(0));
+function resizeLayout() {
+  if (!radarCanvas) return;
+  const size = Math.min(window.innerWidth * 0.3, 300);
+  radarCanvas.width = size;
+  radarCanvas.height = size;
+  const footer = document.getElementById('average-container');
+  if (footer) {
+    document.body.style.setProperty('--footer-height', `${footer.offsetHeight}px`);
+  }
+  drawRadarChart(currentChartValues);
+}
+
+window.addEventListener('resize', resizeLayout);
+resizeLayout();
 
 function addItem(item) {
   kpiItems.push(item);
@@ -298,7 +313,12 @@ kpiData.forEach(section => {
       if (span) span.textContent = avg;
     });
     const chartValues = attributeKeys.map(key => attrCounts[key] ? (attrTotals[key] / attrCounts[key]) : 0);
+    currentChartValues = chartValues;
     drawRadarChart(chartValues);
+    const footer = document.getElementById('average-container');
+    if (footer) {
+      document.body.style.setProperty('--footer-height', `${footer.offsetHeight}px`);
+    }
   }
 
 function setRating(wrapper, rating) {

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <textarea id="summary-focus" class="summary-input"></textarea>
     </div>
     <div id="average-container">
-        <canvas id="radar-chart" width="150" height="150"></canvas>
+        <canvas id="radar-chart"></canvas>
         <div id="score-container">
             <div id="overall-average">総合スコア <span id="average">0</span> / 100</div>
             <div id="attribute-averages">

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.6;
   margin: 0;
-  padding: 0 20px 200px;
+  padding: 0 20px var(--footer-height, 200px);
   background-color: #f5f7fa;
   color: #333;
 }
@@ -50,11 +50,12 @@ input[type="file"] {
   align-items: center;
   justify-content: center;
   gap: 20px;
+  flex-wrap: wrap;
 }
 
 #radar-chart {
-  width: 150px;
-  height: 150px;
+  width: clamp(200px, 30vw, 300px);
+  height: clamp(200px, 30vw, 300px);
   margin: 0 20px 0 0;
 }
 


### PR DESCRIPTION
## Summary
- Resize radar chart responsively and adjust footer spacing so chart labels aren’t clipped
- Restore default radar chart label color and keep it consistent on redraw

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5245d3858832689b5031963c3d712