### PR TITLE
Adjust radar chart canvas to 3:2 aspect

### DIFF
--- a/app.js
+++ b/app.js
@@ -187,9 +187,11 @@ function drawRadarChart(values) {
 
 function resizeLayout() {
   if (!radarCanvas) return;
-  const size = Math.min(window.innerWidth * 0.3, 300);
-  radarCanvas.width = size;
-  radarCanvas.height = size;
+  // Base canvas height on viewport width, then widen to a 3:2 ratio
+  const height = Math.min(Math.max(window.innerWidth * 0.3, 200), 300);
+  const width = height * 1.5;
+  radarCanvas.width = width;
+  radarCanvas.height = height;
   const footer = document.getElementById('average-container');
   if (footer) {
     document.body.style.setProperty('--footer-height', `${footer.offsetHeight}px`);

--- a/style.css
+++ b/style.css
@@ -54,7 +54,8 @@ input[type="file"] {
 }
 
 #radar-chart {
-  width: clamp(200px, 30vw, 300px);
+  /* Wider aspect ratio (3:2) so horizontal labels aren't cut off */
+  width: clamp(300px, 45vw, 450px);
   height: clamp(200px, 30vw, 300px);
   margin: 0 20px 0 0;
 }


### PR DESCRIPTION
## Summary
- widen radar chart canvas to a 3:2 aspect ratio so horizontal labels are not cut off
- update CSS and resize logic for canvas with new ratio

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c52889109c83269fefba1eb34a8331