### PR TITLE
Reduce footer height by scaling radar chart canvas

### DIFF
--- a/app.js
+++ b/app.js
@@ -188,7 +188,7 @@ function drawRadarChart(values) {
 function resizeLayout() {
   if (!radarCanvas) return;
   // Base canvas height on viewport width, then widen to a 3:2 ratio
-  const height = Math.min(Math.max(window.innerWidth * 0.3, 200), 300);
+  const height = Math.min(Math.max(window.innerWidth * 0.2, 133), 200);
   const width = height * 1.5;
   radarCanvas.width = width;
   radarCanvas.height = height;

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.6;
   margin: 0;
-  padding: 0 20px var(--footer-height, 200px);
+  padding: 0 20px var(--footer-height, 133px);
   background-color: #f5f7fa;
   color: #333;
 }
@@ -55,8 +55,8 @@ input[type="file"] {
 
 #radar-chart {
   /* Wider aspect ratio (3:2) so horizontal labels aren't cut off */
-  width: clamp(300px, 45vw, 450px);
-  height: clamp(200px, 30vw, 300px);
+  width: clamp(200px, 30vw, 300px);
+  height: clamp(133px, 20vw, 200px);
   margin: 0 20px 0 0;
 }
 


### PR DESCRIPTION
## Summary
- shrink radar chart canvas to 2/3 of its former size while keeping 3:2 ratio
- adjust dynamic layout logic and body padding to match new footer height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c52a1fd28483269a7cc174d6631821