### PR TITLE
Remove JSON import functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Valoinsight
 
-Simple static site to visualise VALORANT match KPI scores. KPI items are hard-coded and scores can be entered manually. The page displays the average score of the entered KPIs. The evaluation and summary notes can also be exported as a JSON file via the **エクスポート** button in the fixed footer. Previously exported data can be loaded back into the page using the **インポート** button.
+Simple static site to visualise VALORANT match KPI scores. KPI items are hard-coded and scores can be entered manually. The page displays the average score of the entered KPIs. The evaluation and summary notes can also be exported as a JSON file via the **エクスポート** button in the fixed footer.
 
 ## Usage
 

--- a/app.js
+++ b/app.js
@@ -358,52 +358,6 @@ if (csvInput) {
   });
 }
 
-const importInput = document.getElementById('import-json');
-if (importInput) {
-  importInput.addEventListener('change', e => {
-    const file = e.target.files[0];
-    if (!file) return;
-
-    const reader = new FileReader();
-    const inputEl = e.target;
-    reader.onload = function(evt) {
-      try {
-        const data = JSON.parse(evt.target.result);
-        if (data.kpiElements) {
-          data.kpiElements.forEach(item => {
-            const wrapper = document.getElementById(item.id);
-            if (wrapper) {
-              const rating = (item.score || 0) / 20;
-              setRating(wrapper, rating);
-              const skipCheckbox = document.getElementById(`${item.id}-skip`);
-              if (skipCheckbox) {
-                skipCheckbox.checked = !!item.skip;
-              }
-            }
-          });
-        }
-        if (data.textnotes) {
-          summaryNotes.good = data.textnotes.wasgood || '';
-          summaryNotes.bad = data.textnotes.wasbad || '';
-          summaryNotes.focus = data.textnotes.important || '';
-          const goodEl = document.getElementById('summary-good');
-          const badEl = document.getElementById('summary-bad');
-          const focusEl = document.getElementById('summary-focus');
-          if (goodEl) goodEl.value = summaryNotes.good;
-          if (badEl) badEl.value = summaryNotes.bad;
-          if (focusEl) focusEl.value = summaryNotes.focus;
-        }
-        updateAverage();
-      } catch (err) {
-        console.error('Failed to parse JSON:', err);
-      } finally {
-        // reset input value after processing so the same file can be re-imported
-        inputEl.value = '';
-      }
-    };
-    reader.readAsText(file);
-  });
-}
 
 document.getElementById('export-btn').addEventListener('click', () => {
   const kpiElements = kpiItems.map(item => {

--- a/index.html
+++ b/index.html
@@ -8,10 +8,6 @@
 </head>
 <body>
     <h1>VALORANT KPI採点ツール</h1>
-    <div id="import-container">
-        <input type="file" id="import-json" accept="application/json" style="display: none;">
-        <label for="import-json" id="import-btn">jsonファイルを読み込む</label>
-    </div>
     <form id="kpi-form">
         <div id="kpi-container"></div>
     </form>

--- a/style.css
+++ b/style.css
@@ -19,16 +19,6 @@ h1 {
   font-size: var(--heading-font-size);
 }
 
-input[type="file"] {
-  display: block;
-  margin: 0 auto 20px;
-  padding: 8px 12px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  background-color: #fff;
-  cursor: pointer;
-}
-
 #kpi-container {
   width: 95%;
   margin: 0 auto;
@@ -87,21 +77,6 @@ input[type="file"] {
     transform: none;
     padding: 6px 12px;
     font-size: 1rem;
-}
-
-#import-container {
-    text-align: center;
-    margin-bottom: 20px;
-}
-
-#import-btn {
-    display: inline-block;
-    padding: 6px 12px;
-    font-size: 1rem;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    background-color: #fff;
-    cursor: pointer;
 }
 
 .section-heading {


### PR DESCRIPTION
## Summary
- remove UI and JS for JSON data import
- clean up unused styles and docs referencing import

## Testing
- `node --check app.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c54b255b408326a06c312a8f7f8287