### PR TITLE
refactor: update radar chart categories

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,27 +2,27 @@ const kpiData = [
   {
     heading: '編成中',
     items: [
-      { id: 'remember-vc', text: '誰のVCが無いか覚えてましたか', attribute: 'pregame' },
-      { id: 'role-balance', text: 'ロール過不足は認識できましたか', note: ['エントリー/索敵/スモーク/トラップ/フラッシュ'], attribute: 'pregame' },
-      { id: 'strategy-axis', text: '編成から立ち回りの軸を見いだせましたか', attribute: 'pregame' }
+      { id: 'remember-vc', text: '誰のVCが無いか覚えてましたか', attribute: 'study' },
+      { id: 'role-balance', text: 'ロール過不足は認識できましたか', note: ['エントリー/索敵/スモーク/トラップ/フラッシュ'], attribute: 'study' },
+      { id: 'strategy-axis', text: '編成から立ち回りの軸を見いだせましたか', attribute: 'study' }
     ]
   },
   {
     heading: '1st準備フェーズ',
     items: [
-      { id: 'self-role', text: '自分がロールを全うすべきか/イレギュラー対応すべきか判断できましたか', note: ['・0デュエ2イニシ編成で自分イニシ → 自分がデュエ的な戦う動きをする', '・攻めでサイファーが逆サイト管理してくれそう → デフォルト戦術', '・イニシがデュエにくっついてアビリティ投げそう → ラッシュ可能かも'], attribute: 'pregame' },
-      { id: 'ally-counter', text: '必要に応じて適切に: 敵編成に対するアンチ戦術考案と味方への声掛けはできましたか', note: ['・味方が敵の編成から対策を考えられそうか判断する', '・ネオンがワイヤーのある所に行かなそうか、行くとしてもアンチワイヤーを考えていそうか、など'], attribute: 'pregame' },
-      { id: 'weird-teammate', text: '味方に変な奴がいる場合: その人との連携プレイの優先度を下げる決意をしましたか', note: ['・名前が「SDGs」「◯◯トロールします」', '・VCで明らかに様子がおかしい'], attribute: 'pregame' }
+      { id: 'self-role', text: '自分がロールを全うすべきか/イレギュラー対応すべきか判断できましたか', note: ['・0デュエ2イニシ編成で自分イニシ → 自分がデュエ的な戦う動きをする', '・攻めでサイファーが逆サイト管理してくれそう → デフォルト戦術', '・イニシがデュエにくっついてアビリティ投げそう → ラッシュ可能かも'], attribute: 'thinking' },
+      { id: 'ally-counter', text: '必要に応じて適切に: 敵編成に対するアンチ戦術考案と味方への声掛けはできましたか', note: ['・味方が敵の編成から対策を考えられそうか判断する', '・ネオンがワイヤーのある所に行かなそうか、行くとしてもアンチワイヤーを考えていそうか、など'], attribute: 'thinking' },
+      { id: 'weird-teammate', text: '味方に変な奴がいる場合: その人との連携プレイの優先度を下げる決意をしましたか', note: ['・名前が「SDGs」「◯◯トロールします」', '・VCで明らかに様子がおかしい'], attribute: 'thinking' }
     ]
   },
   {
     heading: '各ラウンドの準備フェーズ',
     items: [
-      { id: 'weapon-econ', text: '敵味方の武器管理を適切に行えましたか', note: ['・味方がハーフで4人買える時に呼びかけ', '・敵がエコかどうか', '・敵にオペレーターが出る可能性があるか'], attribute: 'macro' },
-      { id: 'ult-management', text: '敵味方のアルティメット管理を適切に行えましたか', note: ['・広範囲デバフ系ウルト(KJ, ブリーチ など)によってどう仕掛けるか・仕掛けられるか'], attribute: 'macro' },
-      { id: 'emotion-reset', text: '前ラウンドの感情処理を5秒以内に終わらせましたか', note: ['・残20秒までに次の話を始められないと味方に浸透しない'], attribute: 'macro' },
-      { id: 'counter-plan', text: '前のラウンドの内容をもとに適切に対策を考えられましたか', attribute: 'macro' },
-      { id: 'propose-strat', text: '必要に応じて作戦を提案できましたか', attribute: 'macro' }
+      { id: 'weapon-econ', text: '敵味方の武器管理を適切に行えましたか', note: ['・味方がハーフで4人買える時に呼びかけ', '・敵がエコかどうか', '・敵にオペレーターが出る可能性があるか'], attribute: 'thinking' },
+      { id: 'ult-management', text: '敵味方のアルティメット管理を適切に行えましたか', note: ['・広範囲デバフ系ウルト(KJ, ブリーチ など)によってどう仕掛けるか・仕掛けられるか'], attribute: 'thinking' },
+      { id: 'emotion-reset', text: '前ラウンドの感情処理を5秒以内に終わらせましたか', note: ['・残20秒までに次の話を始められないと味方に浸透しない'], attribute: 'thinking' },
+      { id: 'counter-plan', text: '前のラウンドの内容をもとに適切に対策を考えられましたか', attribute: 'thinking' },
+      { id: 'propose-strat', text: '必要に応じて作戦を提案できましたか', attribute: 'thinking' }
     ]
   },
   {
@@ -48,37 +48,37 @@ const kpiData = [
       {
         heading: '盤面管理',
         items: [
-          { id: 'engage-decision', text: '接敵していいか判断してからピークしましたか', attribute: 'macro' },
-          { id: 'reposition', text: '必要に応じて適切にポジションを変えましたか', attribute: 'macro' },
-          { id: 'consider-enemy-count', text: 'エントリー時に敵の数と質の両方を考慮しましたか', attribute: 'macro' },
-          { id: 'not-miss-rotate', text: 'ローテートが出来る状況を見落としませんでしたか', attribute: 'macro' },
-          { id: 'rotate-reason', text: 'ローテートする判断の際、適切な根拠はありましたか', attribute: 'macro' },
-          { id: 'ult-change', text: '敵味方のアルティメット状況変化を認識していましたか', attribute: 'macro' },
-          { id: 'silent-steps', text: '必要に応じて適切に足音を消せましたか', note: ['・ラウンド開始直後の情報取り段階', '・ローテート画策中'], attribute: 'macro' },
-          { id: 'push-care', text: 'プッシュケアできましたか', attribute: 'macro' },
-          { id: 'scoreboard-check', text: '可能な時、オーブとプラントの音でスコアボードを確認できましたか', attribute: 'macro' },
-          { id: 'backstab-care', text: '裏取りされうるエリアで適切に警戒できましたか', attribute: 'macro' },
-          { id: 'clearing', text: 'クリアリングミスはありませんでしたか', attribute: 'macro' }
+          { id: 'engage-decision', text: '接敵していいか判断してからピークしましたか', attribute: 'judgement' },
+          { id: 'reposition', text: '必要に応じて適切にポジションを変えましたか', attribute: 'judgement' },
+          { id: 'consider-enemy-count', text: 'エントリー時に敵の数と質の両方を考慮しましたか', attribute: 'judgement' },
+          { id: 'not-miss-rotate', text: 'ローテートが出来る状況を見落としませんでしたか', attribute: 'judgement' },
+          { id: 'rotate-reason', text: 'ローテートする判断の際、適切な根拠はありましたか', attribute: 'judgement' },
+          { id: 'ult-change', text: '敵味方のアルティメット状況変化を認識していましたか', attribute: 'judgement' },
+          { id: 'silent-steps', text: '必要に応じて適切に足音を消せましたか', note: ['・ラウンド開始直後の情報取り段階', '・ローテート画策中'], attribute: 'judgement' },
+          { id: 'push-care', text: 'プッシュケアできましたか', attribute: 'judgement' },
+          { id: 'scoreboard-check', text: '可能な時、オーブとプラントの音でスコアボードを確認できましたか', attribute: 'judgement' },
+          { id: 'backstab-care', text: '裏取りされうるエリアで適切に警戒できましたか', attribute: 'judgement' },
+          { id: 'clearing', text: 'クリアリングミスはありませんでしたか', attribute: 'judgement' }
         ]
       },
       {
         heading: 'チームプレイ',
         items: [
-          { id: 'death-call', text: '死亡時に即座に必要なことを報告できましたか', attribute: 'teamwork' },
-          { id: 'ask-help', text: '自分が困った時に適切に助けを要求しましたか', attribute: 'teamwork' },
-          { id: 'follow-entry', text: '適切にエントリーに着いていきましたか', attribute: 'teamwork' },
-          { id: 'support-duelist', text: 'デュエリスト(先頭の人)が困っている時に適切に提案したり、適切に支援アビリティを出せましたか', attribute: 'teamwork' },
-          { id: 'cover-line', text: '必要に応じて適切に味方へのカバーの射線を通せましたか', attribute: 'teamwork' },
-          { id: 'protect-defuser', text: '解除者の射線に敵が立たないようにできましたか', attribute: 'teamwork' }
+          { id: 'death-call', text: '死亡時に即座に必要なことを報告できましたか', attribute: 'teamplay' },
+          { id: 'ask-help', text: '自分が困った時に適切に助けを要求しましたか', attribute: 'teamplay' },
+          { id: 'follow-entry', text: '適切にエントリーに着いていきましたか', attribute: 'teamplay' },
+          { id: 'support-duelist', text: 'デュエリスト(先頭の人)が困っている時に適切に提案したり、適切に支援アビリティを出せましたか', attribute: 'teamplay' },
+          { id: 'cover-line', text: '必要に応じて適切に味方へのカバーの射線を通せましたか', attribute: 'teamplay' },
+          { id: 'protect-defuser', text: '解除者の射線に敵が立たないようにできましたか', attribute: 'teamplay' }
         ]
       },
       {
         heading: 'プラント・ポストプラント',
         items: [
-          { id: 'plant-delay', text: 'どこで遅延行為がしやすいか考えてプラント位置を決めましたか', attribute: 'plant' },
-          { id: 'postplant-position', text: '見方が設置した位置に対して強い位置取りができましたか', attribute: 'plant' },
-          { id: 'ability-awareness', text: '味方と敵の残アビリティを認識できましたか', attribute: 'plant' },
-          { id: 'ally-reaction', text: '味方の動きを見てそれに対応した適切なポジショニングはできましたか', attribute: 'plant' }
+          { id: 'plant-delay', text: 'どこで遅延行為がしやすいか考えてプラント位置を決めましたか', attribute: 'alert' },
+          { id: 'postplant-position', text: '見方が設置した位置に対して強い位置取りができましたか', attribute: 'alert' },
+          { id: 'ability-awareness', text: '味方と敵の残アビリティを認識できましたか', attribute: 'alert' },
+          { id: 'ally-reaction', text: '味方の動きを見てそれに対応した適切なポジショニングはできましたか', attribute: 'alert' }
         ]
       }
     ]
@@ -88,13 +88,14 @@ const kpiData = [
 const kpiItems = [];
 const container = document.getElementById('kpi-container');
 const averageEl = document.getElementById('average');
-const attributeKeys = ['pregame', 'physical', 'macro', 'teamwork', 'plant'];
+const attributeKeys = ['physical', 'teamplay', 'judgement', 'alert', 'thinking', 'study'];
 const attributeLabels = {
-  pregame: 'プレゲーム',
   physical: 'フィジカル',
-  macro: 'マクロ',
-  teamwork: 'チームプレイ',
-  plant: 'プラント'
+  teamplay: 'チームプレイ',
+  judgement: '状況判断',
+  alert: '警戒力',
+  thinking: '思考力',
+  study: '座学'
 };
 
 const radarCanvas = document.getElementById('radar-chart');

--- a/index.html
+++ b/index.html
@@ -25,11 +25,12 @@
         <div id="score-container">
             <div id="overall-average">総合スコア <span id="average">0</span> / 100</div>
             <div id="attribute-averages">
-                <span class="attribute-average">プレゲーム: <span id="avg-pregame">0</span></span>
                 <span class="attribute-average">フィジカル: <span id="avg-physical">0</span></span>
-                <span class="attribute-average">マクロ: <span id="avg-macro">0</span></span>
-                <span class="attribute-average">チームプレイ: <span id="avg-teamwork">0</span></span>
-                <span class="attribute-average">プラント: <span id="avg-plant">0</span></span>
+                <span class="attribute-average">チームプレイ: <span id="avg-teamplay">0</span></span>
+                <span class="attribute-average">状況判断: <span id="avg-judgement">0</span></span>
+                <span class="attribute-average">警戒力: <span id="avg-alert">0</span></span>
+                <span class="attribute-average">思考力: <span id="avg-thinking">0</span></span>
+                <span class="attribute-average">座学: <span id="avg-study">0</span></span>
             </div>
         </div>
         <button id="export-btn">ファイルで保存</button>


### PR DESCRIPTION
## Summary
- Expand radar chart to six metrics and update attribute averages display.
- Define new attribute keys and labels for metrics such as フィジカル and 警戒力.
- Assign preparation-phase KPIs to the 思考力 attribute.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c637fc165c83269707a6462f42218f