### PR TITLE
Align fixed-footer metric scores vertically

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,12 +25,30 @@
         <div id="score-container">
             <div id="overall-average">総合スコア <span id="average">0</span> / 100</div>
             <div id="attribute-averages">
-                <span class="attribute-average">フィジカル: <span id="avg-physical">0</span></span>
-                <span class="attribute-average">チームプレイ: <span id="avg-teamplay">0</span></span>
-                <span class="attribute-average">状況判断: <span id="avg-judgement">0</span></span>
-                <span class="attribute-average">警戒力: <span id="avg-alert">0</span></span>
-                <span class="attribute-average">思考力: <span id="avg-thinking">0</span></span>
-                <span class="attribute-average">座学: <span id="avg-study">0</span></span>
+                <div class="attribute-average">
+                    <span class="attribute-label">フィジカル</span>
+                    <span class="attribute-score"><span id="avg-physical">0</span>点</span>
+                </div>
+                <div class="attribute-average">
+                    <span class="attribute-label">チームプレイ</span>
+                    <span class="attribute-score"><span id="avg-teamplay">0</span>点</span>
+                </div>
+                <div class="attribute-average">
+                    <span class="attribute-label">状況判断</span>
+                    <span class="attribute-score"><span id="avg-judgement">0</span>点</span>
+                </div>
+                <div class="attribute-average">
+                    <span class="attribute-label">警戒力</span>
+                    <span class="attribute-score"><span id="avg-alert">0</span>点</span>
+                </div>
+                <div class="attribute-average">
+                    <span class="attribute-label">思考力</span>
+                    <span class="attribute-score"><span id="avg-thinking">0</span>点</span>
+                </div>
+                <div class="attribute-average">
+                    <span class="attribute-label">座学</span>
+                    <span class="attribute-score"><span id="avg-study">0</span>点</span>
+                </div>
             </div>
         </div>
         <button id="export-btn">ファイルで保存</button>

--- a/style.css
+++ b/style.css
@@ -59,15 +59,23 @@ h1 {
 
 #attribute-averages {
   display: flex;
-  justify-content: flex-start;
-  gap: 10px;
-  flex-wrap: wrap;
+  flex-direction: column;
   font-size: 1rem;
   margin-top: 4px;
 }
 
 .attribute-average {
+  display: flex;
+  align-items: center;
   white-space: nowrap;
+}
+
+.attribute-label {
+  width: 6em;
+}
+
+.attribute-score::before {
+  content: ': ';
 }
 
 #export-btn {


### PR DESCRIPTION
## Summary
- Stack footer attribute averages vertically and add score units
- Align label and score columns for consistent presentation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c63d05025c832689440057e97ada0a