### PR TITLE
Enhance radar chart score display and layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,7 +139,6 @@ function drawRadarChart(values) {
   const angleStep = (Math.PI * 2) / count;
 
   ctx.strokeStyle = '#ccc';
-  ctx.font = '12px sans-serif';
   ctx.fillStyle = '#000';
   for (let i = 0; i < count; i++) {
     const angle = -Math.PI / 2 + i * angleStep;
@@ -151,7 +150,8 @@ function drawRadarChart(values) {
     ctx.stroke();
 
     const label = attributeLabels[attributeKeys[i]] || '';
-    const labelRadius = radius + 10;
+    // leave extra space for the score beneath the label
+    const labelRadius = radius + 12;
     const lx = centerX + labelRadius * Math.cos(angle);
     const ly = centerY + labelRadius * Math.sin(angle);
     if (Math.abs(Math.cos(angle)) < 0.1) {
@@ -164,7 +164,17 @@ function drawRadarChart(values) {
     } else {
       ctx.textBaseline = Math.sin(angle) > 0 ? 'top' : 'bottom';
     }
+    ctx.font = '12px sans-serif';
     ctx.fillText(label, lx, ly);
+
+    // Draw the score just inside the chart under the label
+    const scoreRadius = radius - 4;
+    const sx = centerX + scoreRadius * Math.cos(angle);
+    const sy = centerY + scoreRadius * Math.sin(angle);
+    ctx.font = '10px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(values[i].toFixed(1), sx, sy);
   }
 
   ctx.beginPath();
@@ -189,7 +199,7 @@ function drawRadarChart(values) {
 function resizeLayout() {
   if (!radarCanvas) return;
   // Base canvas height on viewport width, then widen to a 3:2 ratio
-  const height = Math.min(Math.max(window.innerWidth * 0.2, 133), 200);
+  const height = Math.min(Math.max(window.innerWidth * 0.22, 150), 220);
   const width = height * 1.5;
   radarCanvas.width = width;
   radarCanvas.height = height;

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.6;
   margin: 0;
-  padding: 0 20px var(--footer-height, 133px);
+  padding: 0 20px var(--footer-height, 150px);
   background-color: #f5f7fa;
   color: #333;
 }
@@ -31,7 +31,7 @@ h1 {
   left: 0;
   width: 100%;
   background-color: #fff;
-  padding: 5px 10px;
+  padding: 8px 10px;
   border-top: 1px solid #ccc;
   z-index: 1000;
   font-size: var(--heading-font-size);
@@ -45,8 +45,8 @@ h1 {
 
 #radar-chart {
   /* Wider aspect ratio (3:2) so horizontal labels aren't cut off */
-  width: clamp(200px, 30vw, 300px);
-  height: clamp(133px, 20vw, 200px);
+  width: clamp(225px, 33vw, 330px);
+  height: clamp(150px, 22vw, 220px);
   margin: 0 20px 0 0;
 }
 


### PR DESCRIPTION
## Summary
- Show each attribute's score beneath its label in the radar chart using smaller text.
- Slightly enlarge the radar chart canvas and footer to improve readability.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c643f3011483268bf9e43b8745d336