### PR TITLE
feat: color code attribute scores

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,6 +98,16 @@ const attributeLabels = {
   study: '座学'
 };
 
+const rootStyles = getComputedStyle(document.documentElement);
+const attributeColors = {
+  physical: rootStyles.getPropertyValue('--color-physical').trim(),
+  teamplay: rootStyles.getPropertyValue('--color-teamplay').trim(),
+  judgement: rootStyles.getPropertyValue('--color-judgement').trim(),
+  alert: rootStyles.getPropertyValue('--color-alert').trim(),
+  thinking: rootStyles.getPropertyValue('--color-thinking').trim(),
+  study: rootStyles.getPropertyValue('--color-study').trim()
+};
+
 const radarCanvas = document.getElementById('radar-chart');
 const radarCtx = radarCanvas ? radarCanvas.getContext('2d') : null;
 let currentChartValues = new Array(attributeKeys.length).fill(0);
@@ -140,7 +150,6 @@ function drawRadarChart(values) {
 
   ctx.strokeStyle = '#ccc';
   ctx.font = '12px sans-serif';
-  ctx.fillStyle = '#000';
   for (let i = 0; i < count; i++) {
     const angle = -Math.PI / 2 + i * angleStep;
     const x = centerX + radius * Math.cos(angle);
@@ -150,7 +159,8 @@ function drawRadarChart(values) {
     ctx.lineTo(x, y);
     ctx.stroke();
 
-    const label = attributeLabels[attributeKeys[i]] || '';
+    const key = attributeKeys[i];
+    const label = attributeLabels[key] || '';
     const labelRadius = radius + 10;
     const lx = centerX + labelRadius * Math.cos(angle);
     const ly = centerY + labelRadius * Math.sin(angle);
@@ -164,6 +174,29 @@ function drawRadarChart(values) {
     } else {
       ctx.textBaseline = Math.sin(angle) > 0 ? 'top' : 'bottom';
     }
+    const color = attributeColors[key] || '#fff';
+    const metrics = ctx.measureText(label);
+    const padding = 2;
+    const textHeight = metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent;
+    let rectX = lx;
+    if (ctx.textAlign === 'center') {
+      rectX -= metrics.width / 2 + padding;
+    } else if (ctx.textAlign === 'right') {
+      rectX -= metrics.width + padding;
+    } else {
+      rectX -= padding;
+    }
+    let rectY = ly;
+    if (ctx.textBaseline === 'middle') {
+      rectY -= textHeight / 2 + padding;
+    } else if (ctx.textBaseline === 'bottom') {
+      rectY -= textHeight + padding;
+    } else {
+      rectY -= padding;
+    }
+    ctx.fillStyle = color;
+    ctx.fillRect(rectX, rectY, metrics.width + padding * 2, textHeight + padding * 2);
+    ctx.fillStyle = '#000';
     ctx.fillText(label, lx, ly);
   }
 

--- a/index.html
+++ b/index.html
@@ -25,27 +25,27 @@
         <div id="score-container">
             <div id="overall-average">総合スコア <span id="average">0.0</span> / 100</div>
             <div id="attribute-averages">
-                <div class="attribute-average">
+                <div class="attribute-average physical">
                     <span class="attribute-label">フィジカル</span>
                     <span class="attribute-score"><span id="avg-physical">0.0</span></span>
                 </div>
-                <div class="attribute-average">
+                <div class="attribute-average teamplay">
                     <span class="attribute-label">チームプレイ</span>
                     <span class="attribute-score"><span id="avg-teamplay">0.0</span></span>
                 </div>
-                <div class="attribute-average">
+                <div class="attribute-average judgement">
                     <span class="attribute-label">状況判断</span>
                     <span class="attribute-score"><span id="avg-judgement">0.0</span></span>
                 </div>
-                <div class="attribute-average">
+                <div class="attribute-average alert">
                     <span class="attribute-label">警戒力</span>
                     <span class="attribute-score"><span id="avg-alert">0.0</span></span>
                 </div>
-                <div class="attribute-average">
+                <div class="attribute-average thinking">
                     <span class="attribute-label">思考力</span>
                     <span class="attribute-score"><span id="avg-thinking">0.0</span></span>
                 </div>
-                <div class="attribute-average">
+                <div class="attribute-average study">
                     <span class="attribute-label">座学</span>
                     <span class="attribute-score"><span id="avg-study">0.0</span></span>
                 </div>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,12 @@
 /* Simple and refined styling for VALORANT KPI tool */
 :root {
   --heading-font-size: clamp(1.5rem, 5vw, 2rem);
+  --color-physical: #ffd1d1;
+  --color-alert: #ffe8cc;
+  --color-thinking: #d6f5d6;
+  --color-teamplay: #e6d5ff;
+  --color-judgement: #fff9cc;
+  --color-study: #d6f0ff;
 }
 
 body {
@@ -75,12 +81,28 @@ h1 {
   border-radius: 4px;
 }
 
-.attribute-average:nth-child(odd) {
-  background-color: #f1f2f9;
+.attribute-average.physical {
+  background-color: var(--color-physical);
 }
 
-.attribute-average:nth-child(even) {
-  background-color: #f2f5fa;
+.attribute-average.alert {
+  background-color: var(--color-alert);
+}
+
+.attribute-average.thinking {
+  background-color: var(--color-thinking);
+}
+
+.attribute-average.teamplay {
+  background-color: var(--color-teamplay);
+}
+
+.attribute-average.judgement {
+  background-color: var(--color-judgement);
+}
+
+.attribute-average.study {
+  background-color: var(--color-study);
 }
 
 .attribute-label {


### PR DESCRIPTION
## Summary
- color radar chart labels and attribute score rows with matching category colors
- pull CSS variables for attribute hues to keep chart and footer in sync

## Testing
- `npm test`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6455dcd28832682d8db238f82fe5a