### PR TITLE
Color radar chart sectors and round canvas

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,6 +148,21 @@ function drawRadarChart(values) {
 
   const angleStep = (Math.PI * 2) / count;
 
+  // Draw colored background sectors for each attribute
+  for (let i = 0; i < count; i++) {
+    const startAngle = -Math.PI / 2 + i * angleStep;
+    const endAngle = startAngle + angleStep;
+    ctx.beginPath();
+    ctx.moveTo(centerX, centerY);
+    ctx.arc(centerX, centerY, radius, startAngle, endAngle);
+    ctx.closePath();
+    ctx.save();
+    ctx.fillStyle = attributeColors[attributeKeys[i]];
+    ctx.globalAlpha = 0.3;
+    ctx.fill();
+    ctx.restore();
+  }
+
   ctx.strokeStyle = '#ccc';
   ctx.fillStyle = '#000';
   for (let i = 0; i < count; i++) {

--- a/style.css
+++ b/style.css
@@ -54,6 +54,8 @@ h1 {
   width: clamp(225px, 33vw, 330px);
   height: clamp(150px, 22vw, 220px);
   margin: 0 20px 0 0;
+  border-radius: 4px;
+  overflow: hidden;
 }
 
 #score-container {


### PR DESCRIPTION
## Summary
- Shade each radar chart sector with its corresponding attribute color for consistent visual cues.
- Apply rounded corners to the radar chart canvas to match the score display styling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6487915688326b8641bff000cacc3