### PR TITLE
Add GitHub repository link under main heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <h1>VALORANT ふりかえりツール</h1>
+    <p class="github-link"><a href="https://github.com/Nao-Shirotsu/Valoinsight">GitHubリポジトリ</a></p>
     <form id="kpi-form">
         <div id="kpi-container"></div>
     </form>

--- a/style.css
+++ b/style.css
@@ -25,6 +25,12 @@ h1 {
   font-size: var(--heading-font-size);
 }
 
+.github-link {
+  text-align: center;
+  font-size: 0.9rem;
+  margin: -20px 0 20px;
+}
+
 #kpi-container {
   width: 95%;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- add GitHub repository link under the main "VALORANT ふりかえりツール" heading
- style the repository link with smaller centered text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6666157fc8326af6cad5a1650fad9