### PR TITLE
Add map and agent selection UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,6 +87,35 @@ const kpiData = [
 // Build KPI sections including headings while collecting items
 const kpiItems = [];
 const container = document.getElementById('kpi-container');
+const selectionContainer = document.getElementById('selection-container');
+let selectedMap = null;
+let selectedAgent = null;
+
+function buildSelectionRow(letters, className, onSelect) {
+  const row = document.createElement('div');
+  row.classList.add('selection-row');
+  letters.forEach(letter => {
+    const btn = document.createElement('div');
+    btn.textContent = letter;
+    btn.classList.add('selection-button', className);
+    btn.addEventListener('click', () => {
+      Array.from(row.children).forEach(child => child.classList.remove('selected'));
+      btn.classList.add('selected');
+      onSelect(letter);
+    });
+    row.appendChild(btn);
+  });
+  selectionContainer.appendChild(row);
+}
+
+if (selectionContainer) {
+  buildSelectionRow(['A', 'B', 'C'], 'map-button', letter => {
+    selectedMap = letter;
+  });
+  buildSelectionRow(['s', 't', 'u', 'v', 'w'], 'agent-button', letter => {
+    selectedAgent = letter;
+  });
+}
 const averageEl = document.getElementById('average');
 const attributeKeys = ['physical', 'teamplay', 'judgement', 'alert', 'thinking', 'study'];
 const attributeLabels = {
@@ -464,6 +493,8 @@ document.getElementById('export-btn').addEventListener('click', () => {
   };
 
   const exportData = {
+    map: selectedMap,
+    agent: selectedAgent,
     kpiElements,
     textnotes
   };

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <h1>VALORANT ふりかえりツール</h1>
     <p class="github-link"><a href="https://github.com/Nao-Shirotsu/Valoinsight"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" class="github-logo"></a></p>
     <form id="kpi-form">
+        <div id="selection-container"></div>
         <div id="kpi-container"></div>
     </form>
     <div id="summary-container">

--- a/style.css
+++ b/style.css
@@ -40,6 +40,41 @@ h1 {
   margin: 0 auto;
 }
 
+#selection-container {
+  width: 95%;
+  margin: 0 auto 20px;
+}
+
+.selection-row {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.selection-button {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 2px solid #000;
+  cursor: pointer;
+}
+
+.selection-button.selected {
+  border-color: red;
+}
+
+.map-button {
+  width: 80px;
+  height: 80px;
+  font-size: 2rem;
+}
+
+.agent-button {
+  width: 40px;
+  height: 40px;
+  font-size: 1rem;
+}
+
 
 #average-container {
   position: fixed;


### PR DESCRIPTION
## Summary
- Add square map selection buttons A/B/C above KPI sections
- Add half-size agent selection buttons s/t/u/v/w
- Highlight selected buttons in red and include selections in JSON export

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c66b6cf5b48326bbd85cc38f438268