### PR TITLE
Add grading/statistics mode switch

### DIFF
--- a/app.js
+++ b/app.js
@@ -568,26 +568,18 @@ document.getElementById('export-btn').addEventListener('click', () => {
   URL.revokeObjectURL(url);
 });
 
-const modeGradingBtn = document.getElementById('mode-grading');
-const modeStatsBtn = document.getElementById('mode-stats');
+const modeToggle = document.getElementById('mode-toggle');
 
-function setMode(mode) {
-  if (mode === 'stats') {
-    modeGradingBtn.classList.remove('active');
-    modeStatsBtn.classList.add('active');
-    document.getElementById('selection-container').style.display = 'none';
+function applyMode() {
+  if (modeToggle.checked) {
     document.getElementById('kpi-container').style.display = 'none';
     document.getElementById('summary-container').style.display = 'none';
   } else {
-    modeGradingBtn.classList.add('active');
-    modeStatsBtn.classList.remove('active');
-    document.getElementById('selection-container').style.display = '';
     document.getElementById('kpi-container').style.display = '';
     document.getElementById('summary-container').style.display = '';
   }
   updateAverage();
 }
 
-modeGradingBtn.addEventListener('click', () => setMode('grading'));
-modeStatsBtn.addEventListener('click', () => setMode('stats'));
-setMode('grading');
+modeToggle.addEventListener('change', applyMode);
+applyMode();

--- a/app.js
+++ b/app.js
@@ -659,13 +659,19 @@ function applyMode() {
     if (kpiContainer) kpiContainer.style.display = 'none';
     if (summaryContainer) summaryContainer.style.display = 'none';
     if (dropArea) dropArea.style.display = '';
-    if (exportBtn) exportBtn.disabled = true;
+    if (exportBtn) {
+      exportBtn.disabled = true;
+      exportBtn.style.display = 'none';
+    }
     resetScores();
   } else {
     if (kpiContainer) kpiContainer.style.display = '';
     if (summaryContainer) summaryContainer.style.display = '';
     if (dropArea) dropArea.style.display = 'none';
-    if (exportBtn) exportBtn.disabled = false;
+    if (exportBtn) {
+      exportBtn.disabled = false;
+      exportBtn.style.display = '';
+    }
     updateAverage();
   }
 }

--- a/app.js
+++ b/app.js
@@ -571,12 +571,18 @@ document.getElementById('export-btn').addEventListener('click', () => {
 const modeToggle = document.getElementById('mode-toggle');
 
 function applyMode() {
+  const kpiContainer = document.getElementById('kpi-container');
+  const summaryContainer = document.getElementById('summary-container');
+  const exportBtn = document.getElementById('export-btn');
+
   if (modeToggle.checked) {
-    document.getElementById('kpi-container').style.display = 'none';
-    document.getElementById('summary-container').style.display = 'none';
+    if (kpiContainer) kpiContainer.style.display = 'none';
+    if (summaryContainer) summaryContainer.style.display = 'none';
+    if (exportBtn) exportBtn.disabled = true;
   } else {
-    document.getElementById('kpi-container').style.display = '';
-    document.getElementById('summary-container').style.display = '';
+    if (kpiContainer) kpiContainer.style.display = '';
+    if (summaryContainer) summaryContainer.style.display = '';
+    if (exportBtn) exportBtn.disabled = false;
   }
   updateAverage();
 }

--- a/app.js
+++ b/app.js
@@ -567,3 +567,27 @@ document.getElementById('export-btn').addEventListener('click', () => {
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
 });
+
+const modeGradingBtn = document.getElementById('mode-grading');
+const modeStatsBtn = document.getElementById('mode-stats');
+
+function setMode(mode) {
+  if (mode === 'stats') {
+    modeGradingBtn.classList.remove('active');
+    modeStatsBtn.classList.add('active');
+    document.getElementById('selection-container').style.display = 'none';
+    document.getElementById('kpi-container').style.display = 'none';
+    document.getElementById('summary-container').style.display = 'none';
+  } else {
+    modeGradingBtn.classList.add('active');
+    modeStatsBtn.classList.remove('active');
+    document.getElementById('selection-container').style.display = '';
+    document.getElementById('kpi-container').style.display = '';
+    document.getElementById('summary-container').style.display = '';
+  }
+  updateAverage();
+}
+
+modeGradingBtn.addEventListener('click', () => setMode('grading'));
+modeStatsBtn.addEventListener('click', () => setMode('stats'));
+setMode('grading');

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
     <form id="kpi-form">
         <div id="selection-container"></div>
         <div id="kpi-container"></div>
-        <div id="json-drop-area" class="drop-area" style="display:none;">JSONファイルをここにドラッグ＆ドロップ</div>
     </form>
     <div id="summary-container">
         <h2 class="summary-heading">総括ノート</h2>
@@ -25,13 +24,6 @@
         <textarea id="summary-focus" class="summary-input"></textarea>
     </div>
     <div id="average-container">
-        <div id="mode-switch" class="toggle-switch">
-            <input type="checkbox" id="mode-toggle">
-            <label for="mode-toggle" class="toggle-label">
-                <span class="toggle-grading">採点</span>
-                <span class="toggle-stats">統計</span>
-            </label>
-        </div>
         <div id="chart-score-container">
             <canvas id="radar-chart"></canvas>
             <div id="score-container">
@@ -63,8 +55,17 @@
                 </div>
             </div>
         </div>
+        <div id="right-controls">
+            <div id="mode-switch" class="toggle-switch">
+                <input type="checkbox" id="mode-toggle">
+                <label for="mode-toggle" class="toggle-label">
+                    <span class="toggle-grading">採点</span>
+                    <span class="toggle-stats">統計</span>
+                </label>
+            </div>
+            <button id="export-btn">ファイルに保存</button>
+            <div id="json-drop-area" class="drop-area" style="display:none;">JSONファイルをここにドラッグ＆ドロップ</div>
         </div>
-        <button id="export-btn">ファイルに保存</button>
     </div>
     <div id="footer">
         <br><br><br>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <form id="kpi-form">
         <div id="selection-container"></div>
         <div id="kpi-container"></div>
+        <div id="json-drop-area" class="drop-area" style="display:none;">JSONファイルをここにドラッグ＆ドロップ</div>
     </form>
     <div id="summary-container">
         <h2 class="summary-heading">総括ノート</h2>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,10 @@
         <textarea id="summary-focus" class="summary-input"></textarea>
     </div>
     <div id="average-container">
+        <div id="mode-switch">
+            <button id="mode-grading" class="mode-button active">採点</button>
+            <button id="mode-stats" class="mode-button">統計</button>
+        </div>
         <canvas id="radar-chart"></canvas>
         <div id="score-container">
             <div id="overall-average">総合スコア <span id="average">0.0</span> / 100</div>

--- a/index.html
+++ b/index.html
@@ -24,17 +24,21 @@
         <textarea id="summary-focus" class="summary-input"></textarea>
     </div>
     <div id="average-container">
-        <div id="mode-switch">
-            <button id="mode-grading" class="mode-button active">採点</button>
-            <button id="mode-stats" class="mode-button">統計</button>
+        <div id="mode-switch" class="toggle-switch">
+            <input type="checkbox" id="mode-toggle">
+            <label for="mode-toggle" class="toggle-label">
+                <span class="toggle-grading">採点</span>
+                <span class="toggle-stats">統計</span>
+            </label>
         </div>
-        <canvas id="radar-chart"></canvas>
-        <div id="score-container">
-            <div id="overall-average">総合スコア <span id="average">0.0</span> / 100</div>
-            <div id="attribute-averages">
-                <div class="attribute-average physical">
-                    <span class="attribute-label">フィジカル</span>
-                    <span class="attribute-score"><span id="avg-physical">0.0</span></span>
+        <div id="chart-score-container">
+            <canvas id="radar-chart"></canvas>
+            <div id="score-container">
+                <div id="overall-average">総合スコア <span id="average">0.0</span> / 100</div>
+                <div id="attribute-averages">
+                    <div class="attribute-average physical">
+                        <span class="attribute-label">フィジカル</span>
+                        <span class="attribute-score"><span id="avg-physical">0.0</span></span>
                 </div>
                 <div class="attribute-average teamplay">
                     <span class="attribute-label">チームプレイ</span>
@@ -57,6 +61,7 @@
                     <span class="attribute-score"><span id="avg-study">0.0</span></span>
                 </div>
             </div>
+        </div>
         </div>
         <button id="export-btn">ファイルに保存</button>
     </div>

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
             <div id="json-drop-area" class="drop-area" style="display:none;">JSONファイルをここにドラッグ＆ドロップ</div>
         </div>
     </div>
+    </div>
     <div id="footer">
         <br><br><br>
         <hr class="divider">

--- a/style.css
+++ b/style.css
@@ -124,9 +124,27 @@ h1 {
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 20px;
   flex-wrap: wrap;
+}
+
+#mode-switch {
+  display: flex;
+  gap: 6px;
+  margin-right: 20px;
+}
+
+.mode-button {
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  background-color: #f0f0f0;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.mode-button.active {
+  background-color: #d0d0d0;
 }
 
 #radar-chart {

--- a/style.css
+++ b/style.css
@@ -44,13 +44,14 @@ h1 {
 }
 
 #json-drop-area {
-  width: 70%;
-  margin: 20px auto;
-  padding: 40px 10px;
+  width: 25vw;
+  min-width: 150px;
+  padding: 20px 10px;
   border: 2px dashed #bbb;
   text-align: center;
   color: #666;
   background-color: #fafafa;
+  margin: 0;
 }
 
 #json-drop-area.dragover {
@@ -140,12 +141,17 @@ h1 {
   align-items: center;
   justify-content: center;
 }
-#mode-switch {
+#right-controls {
   position: absolute;
-  left: 10px;
-  top: 50%;
-  transform: translateY(-50%);
+  right: 10px;
+  top: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
 }
+/* mode switch positioned via right-controls */
+#mode-switch {}
 
 .toggle-switch input {
   display: none;
@@ -269,10 +275,6 @@ h1 {
 }
 
 #export-btn {
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
   padding: 6px 12px;
   font-size: 1rem;
 }

--- a/style.css
+++ b/style.css
@@ -43,6 +43,21 @@ h1 {
   margin: 0 auto;
 }
 
+#json-drop-area {
+  width: 70%;
+  margin: 20px auto;
+  padding: 40px 10px;
+  border: 2px dashed #bbb;
+  text-align: center;
+  color: #666;
+  background-color: #fafafa;
+}
+
+#json-drop-area.dragover {
+  border-color: #333;
+  background-color: #f0f0f0;
+}
+
 #selection-container {
   width: 95%;
   margin: 0 auto 20px;

--- a/style.css
+++ b/style.css
@@ -122,36 +122,82 @@ h1 {
   z-index: 1000;
   font-size: var(--heading-font-size);
   display: flex;
-  flex-direction: row;
   align-items: center;
-  justify-content: flex-start;
-  gap: 20px;
-  flex-wrap: wrap;
+  justify-content: center;
 }
-
 #mode-switch {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.toggle-switch input {
+  display: none;
+}
+
+.toggle-label {
   display: flex;
-  gap: 6px;
-  margin-right: 20px;
-}
-
-.mode-button {
-  padding: 4px 8px;
-  border: 1px solid #ccc;
-  background-color: #f0f0f0;
+  align-items: center;
+  background-color: #ccc;
+  border-radius: 16px;
   cursor: pointer;
-  font-size: 1rem;
+  position: relative;
+  width: 100px;
+  height: 32px;
+  font-size: 0.9rem;
 }
 
-.mode-button.active {
-  background-color: #d0d0d0;
+.toggle-label span {
+  flex: 1;
+  text-align: center;
+  z-index: 1;
+}
+
+.toggle-label::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: calc(50% - 4px);
+  height: calc(100% - 4px);
+  background: #fff;
+  border-radius: 14px;
+  transition: transform 0.2s;
+}
+
+#mode-toggle:checked + .toggle-label::after {
+  transform: translateX(100%);
+}
+
+#mode-toggle:checked + .toggle-label .toggle-grading {
+  color: #666;
+}
+
+#mode-toggle:checked + .toggle-label .toggle-stats {
+  color: #000;
+}
+
+#mode-toggle:not(:checked) + .toggle-label .toggle-grading {
+  color: #000;
+}
+
+#mode-toggle:not(:checked) + .toggle-label .toggle-stats {
+  color: #666;
+}
+
+#chart-score-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
 }
 
 #radar-chart {
   /* Wider aspect ratio (3:2) so horizontal labels aren't cut off */
   width: clamp(225px, 33vw, 330px);
   height: clamp(150px, 22vw, 220px);
-  margin: 0 20px 0 0;
+  margin: 0;
 }
 
 #score-container {
@@ -208,12 +254,12 @@ h1 {
 }
 
 #export-btn {
-    position: absolute;
-    right: calc(10px + (100vw - 99%));
-    bottom: 10px;
-    transform: none;
-    padding: 6px 12px;
-    font-size: 1rem;
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 6px 12px;
+  font-size: 1rem;
 }
 
 .section-heading {

--- a/style.css
+++ b/style.css
@@ -262,6 +262,11 @@ h1 {
   font-size: 1rem;
 }
 
+#export-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .section-heading {
   margin-top: 20px;
   text-align: left;


### PR DESCRIPTION
## Summary
- add mode toggle in footer to switch between grading and statistics modes
- hide KPI and summary sections when statistics mode is active
- basic styling and script handling for new switch

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c697985cc48326b3bcdb0448279b8b