### PR TITLE
Place mode toggle above file controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,8 +63,10 @@
                     <span class="toggle-stats">統計</span>
                 </label>
             </div>
-            <button id="export-btn">ファイルに保存</button>
-            <div id="json-drop-area" class="drop-area" style="display:none;">JSONファイルをここにドラッグ＆ドロップ</div>
+            <div id="file-controls">
+                <button id="export-btn">ファイルに保存</button>
+                <div id="json-drop-area" class="drop-area" style="display:none;">JSONファイルをここにドラッグ＆ドロップ</div>
+            </div>
         </div>
     </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -148,12 +148,18 @@ h1 {
   top: 8px;
   margin-right: 10%;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: 8px;
 }
 /* mode switch positioned via controls-container */
 #mode-switch {}
+
+#file-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 
 .toggle-switch input {
   display: none;


### PR DESCRIPTION
## Summary
- Move mode toggle above the file save/drag area in the fixed footer
- Stack footer controls vertically and group file controls together

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6aec7713483269cdd9e527343c765