### PR TITLE
Disable KPI interactions and show scores in statistics mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -419,6 +419,10 @@ function addItem(item) {
     starContainer.appendChild(star);
   }
   wrapper.appendChild(starContainer);
+
+  const scoreDisplay = document.createElement('div');
+  scoreDisplay.classList.add('score-display');
+  wrapper.appendChild(scoreDisplay);
   skipCheckbox.addEventListener('change', updateAverage);
   container.appendChild(wrapper);
 }
@@ -656,13 +660,27 @@ function applyMode() {
   const exportBtn = document.getElementById('export-btn');
 
   if (modeToggle.checked) {
-    if (kpiContainer) kpiContainer.style.display = 'none';
+    if (kpiContainer) kpiContainer.style.display = '';
     if (summaryContainer) summaryContainer.style.display = 'none';
     if (dropArea) dropArea.style.display = '';
     if (exportBtn) {
       exportBtn.disabled = true;
       exportBtn.style.display = 'none';
     }
+    kpiItems.forEach(item => {
+      const skipCheckbox = document.getElementById(`${item.id}-skip`);
+      if (skipCheckbox) skipCheckbox.disabled = true;
+      const wrapper = document.getElementById(item.id);
+      if (wrapper) {
+        const starContainer = wrapper.querySelector('.star-rating');
+        if (starContainer) starContainer.classList.add('disabled');
+        const scoreEl = wrapper.querySelector('.score-display');
+        if (scoreEl) {
+          scoreEl.textContent = '55.5';
+          scoreEl.style.display = '';
+        }
+      }
+    });
     resetScores();
   } else {
     if (kpiContainer) kpiContainer.style.display = '';
@@ -672,6 +690,17 @@ function applyMode() {
       exportBtn.disabled = false;
       exportBtn.style.display = '';
     }
+    kpiItems.forEach(item => {
+      const skipCheckbox = document.getElementById(`${item.id}-skip`);
+      if (skipCheckbox) skipCheckbox.disabled = false;
+      const wrapper = document.getElementById(item.id);
+      if (wrapper) {
+        const starContainer = wrapper.querySelector('.star-rating');
+        if (starContainer) starContainer.classList.remove('disabled');
+        const scoreEl = wrapper.querySelector('.score-display');
+        if (scoreEl) scoreEl.style.display = 'none';
+      }
+    });
     updateAverage();
   }
 }

--- a/style.css
+++ b/style.css
@@ -356,6 +356,11 @@ h1 {
   align-self: center;
 }
 
+.star-rating.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
 .star {
   font-size: clamp(1rem, calc(1rem + 0.625vw), 1.6rem);;
   cursor: pointer;
@@ -364,6 +369,13 @@ h1 {
 
 .star.selected {
   color: gold;
+}
+
+.score-display {
+  align-self: center;
+  margin-left: 8px;
+  font-size: 0.9em;
+  display: none;
 }
 
 #summary-container {


### PR DESCRIPTION
## Summary
- Keep KPI section visible while statistics mode is active
- Disable exclude checkboxes and star ratings in statistics mode
- Display placeholder 55.5 score for each KPI item when viewing statistics

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6af5082dc83268476290c324b5043