### PR TITLE
Improve JSON load for stats mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -524,6 +524,19 @@ kpiData.forEach(section => {
     let count = 0;
     if (Array.isArray(data.kpiElements)) {
       data.kpiElements.forEach(el => {
+        const wrapper = document.getElementById(el.id);
+        if (wrapper) {
+          const scoreEl = wrapper.querySelector('.score-display');
+          if (scoreEl) {
+            if (el.skip) {
+              scoreEl.textContent = 'N/A';
+            } else if (typeof el.score === 'number') {
+              scoreEl.textContent = Number(el.score).toFixed(1);
+            } else {
+              scoreEl.textContent = statsPlaceholderValue;
+            }
+          }
+        }
         if (el.skip) return;
         const score = typeof el.score === 'number' ? el.score : 0;
         total += score;


### PR DESCRIPTION
## Summary
- show KPI scores from dropped JSON in stats mode
- display N/A when items are marked skipped

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b718116c8326a8fb2f9913062c39