### PR TITLE
Add map and agent filtering for stats

### DIFF
--- a/app.js
+++ b/app.js
@@ -142,7 +142,9 @@ if (selectionContainer) {
   ];
   buildSelectionRow(mapOptions, 'map-button', value => {
     selectedMap = value;
-    refreshStats();
+    if (modeToggle.checked) {
+      refreshStats();
+    }
   });
 
   const agentOptions = [
@@ -176,7 +178,9 @@ if (selectionContainer) {
   ];
   buildSelectionRow(agentOptions, 'agent-button', value => {
     selectedAgent = value;
-    refreshStats();
+    if (modeToggle.checked) {
+      refreshStats();
+    }
   });
 
   const selectionDivider = document.createElement('hr');
@@ -603,6 +607,7 @@ kpiData.forEach(section => {
   }
 
   function refreshStats() {
+    if (!modeToggle.checked) return;
     const filtered = loadedDatasets.filter(data => {
       if (selectedMap && data.map !== selectedMap) return false;
       if (selectedAgent && data.agent !== selectedAgent) return false;

--- a/app.js
+++ b/app.js
@@ -137,6 +137,7 @@ if (selectionContainer) {
   ];
   buildSelectionRow(mapOptions, 'map-button', value => {
     selectedMap = value;
+    refreshStats();
   });
 
   const agentOptions = [
@@ -170,6 +171,7 @@ if (selectionContainer) {
   ];
   buildSelectionRow(agentOptions, 'agent-button', value => {
     selectedAgent = value;
+    refreshStats();
   });
 
   const selectionDivider = document.createElement('hr');
@@ -523,10 +525,7 @@ kpiData.forEach(section => {
     drawRadarChart(zeros);
   }
 
-  function loadJsonData(dataArray) {
-    loadedDatasets = [];
-    const incoming = Array.isArray(dataArray) ? dataArray : [dataArray];
-    loadedDatasets.push(...incoming);
+  function updateStats(dataArray) {
     const attrTotals = {};
     const attrCounts = {};
     attributeKeys.forEach(key => {
@@ -541,7 +540,7 @@ kpiData.forEach(section => {
     });
     let total = 0;
     let count = 0;
-    loadedDatasets.forEach(data => {
+    dataArray.forEach(data => {
       if (!Array.isArray(data.kpiElements)) return;
       data.kpiElements.forEach(el => {
         if (el.skip) return;
@@ -596,6 +595,22 @@ kpiData.forEach(section => {
     if (footer) {
       document.body.style.setProperty('--footer-height', `${footer.offsetHeight}px`);
     }
+  }
+
+  function refreshStats() {
+    const filtered = loadedDatasets.filter(data => {
+      if (selectedMap && data.map !== selectedMap) return false;
+      if (selectedAgent && data.agent !== selectedAgent) return false;
+      return true;
+    });
+    updateStats(filtered);
+  }
+
+  function loadJsonData(dataArray) {
+    loadedDatasets = [];
+    const incoming = Array.isArray(dataArray) ? dataArray : [dataArray];
+    loadedDatasets.push(...incoming);
+    refreshStats();
   }
 
 function setRating(wrapper, rating) {

--- a/app.js
+++ b/app.js
@@ -111,9 +111,14 @@ function buildSelectionRow(options, className, onSelect) {
       btn.appendChild(label);
     }
     btn.addEventListener('click', () => {
+      const isSelected = btn.classList.contains('selected');
       Array.from(row.children).forEach(child => child.classList.remove('selected'));
-      btn.classList.add('selected');
-      onSelect(value);
+      if (isSelected) {
+        onSelect(null);
+      } else {
+        btn.classList.add('selected');
+        onSelect(value);
+      }
     });
     row.appendChild(btn);
   });


### PR DESCRIPTION
## Summary
- recalculate statistics based on selected map or agent
- trigger stat refresh when map or agent selection changes

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68c6c4d6219c8326ba12e6796ff73bd4