### PR TITLE
Align KPI stats row and enlarge score number

### DIFF
--- a/app.js
+++ b/app.js
@@ -583,10 +583,11 @@ kpiData.forEach(section => {
       if (!scoreContainer || !scoreEl || !countEl) return;
       if (kpiCounts[item.id]) {
         countEl.textContent = `該当 ${kpiCounts[item.id]} 件`;
-        scoreEl.textContent = `平均スコア ${(kpiTotals[item.id] / kpiCounts[item.id]).toFixed(1)}`;
+        const avg = (kpiTotals[item.id] / kpiCounts[item.id]).toFixed(1);
+        scoreEl.innerHTML = `平均スコア <span class="score-number">${avg}</span>`;
       } else {
         countEl.textContent = '該当 0 件';
-        scoreEl.textContent = 'N/A';
+        scoreEl.innerHTML = '平均スコア <span class="score-number">N/A</span>';
       }
       scoreContainer.style.display = 'flex';
     });
@@ -804,7 +805,7 @@ function applyMode() {
         const scoreEl = wrapper.querySelector('.score-display');
         const countEl = wrapper.querySelector('.data-count');
         if (scoreContainer && scoreEl && countEl) {
-          scoreEl.textContent = `平均スコア ${statsPlaceholderValue}`;
+          scoreEl.innerHTML = `平均スコア <span class="score-number">${statsPlaceholderValue}</span>`;
           countEl.textContent = '該当 0 件';
           scoreContainer.style.display = 'flex';
         }

--- a/style.css
+++ b/style.css
@@ -310,7 +310,7 @@ h1 {
 
 .kpi-item {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 10px;
   margin: 8px 0;
   padding: 4px 8px;
@@ -393,6 +393,14 @@ h1 {
 
 .score-display {
   font-size: 1.2em;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.score-number {
+  font-size: 2em;
+  line-height: 1;
 }
 
 #summary-container {


### PR DESCRIPTION
## Summary
- vertically center KPI stat labels within each KPI row
- double the size of numeric score while keeping label size unchanged
- render score text with separate span for enlarged number

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6caf39fcc83268012ae8d0695f1ed