### PR TITLE
Remove legacy flat KPI element export

### DIFF
--- a/app.js
+++ b/app.js
@@ -529,10 +529,6 @@ function forEachKpiElement(data, callback) {
         });
       }
     });
-    return;
-  }
-  if (Array.isArray(data.kpiElements)) {
-    data.kpiElements.forEach(item => callback(item, null, null));
   }
 }
 
@@ -922,14 +918,6 @@ document.getElementById('export-btn').addEventListener('click', () => {
     }
   });
 
-  const flatElements = [];
-  groupOrder.forEach(group => {
-    group.items.forEach(el => flatElements.push(el));
-    group.subsections.forEach(sub => {
-      sub.items.forEach(el => flatElements.push(el));
-    });
-  });
-
   const textnotes = {
     wasgood: summaryNotes.good,
     wasbad: summaryNotes.bad,
@@ -940,7 +928,6 @@ document.getElementById('export-btn').addEventListener('click', () => {
     map: selectedMap,
     agent: selectedAgent,
     kpiGroups: groupOrder,
-    kpiElements: flatElements,
     textnotes
   };
 


### PR DESCRIPTION
## Summary
- drop the redundant flat KPI element array from the export payload
- remove legacy reader fallback that expected `kpiElements`

## Testing
- node - <<'NODE'
const summaryNotes = { good: ['a'], bad: ['b'], focus: ['c'] };
const selectedMap = 'ascent';
const selectedAgent = 'jett';
const groupOrder = [{ heading: 'Test', items: [], subsections: [] }];
const exportData = {
  map: selectedMap,
  agent: selectedAgent,
  kpiGroups: groupOrder,
  textnotes: {
    wasgood: summaryNotes.good,
    wasbad: summaryNotes.bad,
    important: summaryNotes.focus
  }
};
console.log(JSON.stringify(exportData, null, 2));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cceab5f99c83268d49c36d33aef96b