### PR TITLE
Adjust KPI item layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -422,8 +422,23 @@ function addItem(item, sectionHeading = null, subsectionHeading = null) {
 
   kpiItems.push(normalized);
   const wrapper = document.createElement('div');
-  wrapper.classList.add('kpi-item');
+  wrapper.classList.add('kpi-item-row');
   wrapper.id = normalized.id;
+
+  const skipContainer = document.createElement('div');
+  skipContainer.classList.add('skip-container');
+  const skipCheckbox = document.createElement('input');
+  skipCheckbox.type = 'checkbox';
+  skipCheckbox.id = `${normalized.id}-skip`;
+  const skipLabel = document.createElement('label');
+  skipLabel.setAttribute('for', `${normalized.id}-skip`);
+  skipLabel.textContent = '除外';
+  skipLabel.classList.add('skip-label');
+  skipContainer.appendChild(skipCheckbox);
+  skipContainer.appendChild(skipLabel);
+
+  const itemContainer = document.createElement('div');
+  itemContainer.classList.add('kpi-item');
 
   const textContainer = document.createElement('div');
   textContainer.classList.add('kpi-text');
@@ -453,20 +468,10 @@ function addItem(item, sectionHeading = null, subsectionHeading = null) {
   });
   textContainer.appendChild(tagContainer);
 
-  wrapper.appendChild(textContainer);
+  itemContainer.appendChild(textContainer);
 
-  const skipContainer = document.createElement('div');
-  skipContainer.classList.add('skip-container');
-  const skipCheckbox = document.createElement('input');
-  skipCheckbox.type = 'checkbox';
-  skipCheckbox.id = `${normalized.id}-skip`;
-  const skipLabel = document.createElement('label');
-  skipLabel.setAttribute('for', `${normalized.id}-skip`);
-  skipLabel.textContent = '除外';
-  skipLabel.classList.add('skip-label');
-  skipContainer.appendChild(skipCheckbox);
-  skipContainer.appendChild(skipLabel);
-  wrapper.appendChild(skipContainer);
+  const bottomContainer = document.createElement('div');
+  bottomContainer.classList.add('kpi-bottom');
 
   const starContainer = document.createElement('div');
   starContainer.classList.add('star-rating');
@@ -483,7 +488,7 @@ function addItem(item, sectionHeading = null, subsectionHeading = null) {
     });
     starContainer.appendChild(star);
   }
-  wrapper.appendChild(starContainer);
+  bottomContainer.appendChild(starContainer);
 
   const scoreWrapper = document.createElement('div');
   scoreWrapper.classList.add('score-container');
@@ -496,8 +501,22 @@ function addItem(item, sectionHeading = null, subsectionHeading = null) {
   scoreDisplay.classList.add('score-display');
   scoreWrapper.appendChild(scoreDisplay);
 
-  wrapper.appendChild(scoreWrapper);
-  skipCheckbox.addEventListener('change', updateAverage);
+  bottomContainer.appendChild(scoreWrapper);
+
+  itemContainer.appendChild(bottomContainer);
+
+  wrapper.appendChild(skipContainer);
+  wrapper.appendChild(itemContainer);
+  const syncExcludedState = () => {
+    const isExcluded = !!skipCheckbox.checked;
+    wrapper.classList.toggle('excluded', isExcluded);
+    itemContainer.classList.toggle('excluded', isExcluded);
+  };
+  skipCheckbox.addEventListener('change', () => {
+    syncExcludedState();
+    updateAverage();
+  });
+  syncExcludedState();
   container.appendChild(wrapper);
 }
 

--- a/style.css
+++ b/style.css
@@ -314,14 +314,48 @@ h1 {
   margin: 20px 0;
 }
 
+.kpi-item-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: stretch;
+  margin: 8px 0;
+}
+
 .kpi-item {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  margin: 8px 0;
-  padding: 4px 8px;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 12px;
   border-radius: 1% / 7%;
   background-color: #f1f2fb;
+  min-height: 100%;
+}
+
+.kpi-item-row.excluded .kpi-item,
+.kpi-item.excluded {
+  background-color: #d9dce3;
+  color: #666;
+}
+
+.kpi-item-row.excluded .item-note,
+.kpi-item.excluded .item-note {
+  color: #777;
+}
+
+.kpi-item-row.excluded .attribute-tag,
+.kpi-item.excluded .attribute-tag {
+  opacity: 0.7;
+}
+
+.kpi-item-row.excluded .star,
+.kpi-item.excluded .star {
+  color: #bbb;
+}
+
+.kpi-item-row.excluded .star.selected,
+.kpi-item.excluded .star.selected {
+  color: #d4c86b;
 }
 
 .kpi-text {
@@ -353,8 +387,9 @@ h1 {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2px;
-  align-self: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px 0;
 }
 
 .skip-label {
@@ -365,7 +400,16 @@ h1 {
 .star-rating {
   display: flex;
   gap: 4px;
-  align-self: center;
+  justify-content: center;
+}
+
+.kpi-bottom {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
 }
 
 .star-rating.disabled {
@@ -386,7 +430,7 @@ h1 {
 .score-container {
   display: none;
   align-items: center;
-  margin-left: 8px;
+  justify-content: center;
   gap: 6px;
 }
 


### PR DESCRIPTION
## Summary
- wrap each KPI row with a new container so the exclusion checkbox can sit just outside the KPI card on the left
- restructure the KPI card markup to group the star rating and stats display in a bottom section centered within the card
- update styles to support the new row layout, centering the star rating at the card bottom and aligning the exclusion control vertically
- grey out KPI cards when their exclusion checkbox is selected so the state is visually clear

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ccfe613adc83268deff49f4639ed7d