### PR TITLE
Adjust KPI control sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -358,7 +358,7 @@ h1 {
 }
 
 .skip-label {
-  font-size: 0.625em;
+  font-size: 0.9375em;
   text-align: center;
 }
 
@@ -368,13 +368,17 @@ h1 {
   align-self: center;
 }
 
+.skip-container input[type="checkbox"] {
+  transform: scale(1.75);
+}
+
 .star-rating.disabled {
   pointer-events: none;
   opacity: 0.5;
 }
 
 .star {
-  font-size: clamp(1rem, calc(1rem + 0.625vw), 1.6rem);;
+  font-size: clamp(1.5vw, calc(1rem + 1vw), 3vw);
   cursor: pointer;
   color: #ccc;
 }


### PR DESCRIPTION
## Summary
- enlarge the skip checkbox and label to improve visibility on KPI rows
- update KPI star rating font sizing to use clamp(1.5vw, calc(1rem + 1vw), 3vw)

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd068f7360832696d6029bead5d0b5