### PR TITLE
Adjust skip checkbox vertical alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,6 +7,7 @@
   --color-teamplay: #e6d5ff;
   --color-judgement: #fff9cc;
   --color-study: #d6f0ff;
+  --skip-label-offset: 0.75rem;
 }
 
 body {
@@ -350,14 +351,20 @@ h1 {
 }
 
 .skip-container {
+  position: relative;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 2px;
+  justify-content: center;
   align-self: center;
+  padding-bottom: var(--skip-label-offset);
+  transform: translateY(calc(var(--skip-label-offset) / 2));
 }
 
 .skip-label {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
   font-size: 0.625em;
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- center KPI exclusion checkbox rows using the checkbox as the alignment anchor
- keep the "除外" label positioned under the checkbox with absolute positioning and shared spacing variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd0c28ed7c83269b3cc5ec12f05b30