### PR TITLE
Grey out KPI rows when excluded

### DIFF
--- a/app.js
+++ b/app.js
@@ -497,7 +497,16 @@ function addItem(item, sectionHeading = null, subsectionHeading = null) {
   scoreWrapper.appendChild(scoreDisplay);
 
   wrapper.appendChild(scoreWrapper);
-  skipCheckbox.addEventListener('change', updateAverage);
+  const updateSkipAppearance = () => {
+    wrapper.classList.toggle('kpi-item-skipped', skipCheckbox.checked);
+  };
+
+  skipCheckbox.addEventListener('change', () => {
+    updateSkipAppearance();
+    updateAverage();
+  });
+
+  updateSkipAppearance();
   container.appendChild(wrapper);
 }
 

--- a/style.css
+++ b/style.css
@@ -324,6 +324,24 @@ h1 {
   background-color: #f1f2fb;
 }
 
+.kpi-item.kpi-item-skipped {
+  background-color: #d9dbe2;
+  color: #777;
+}
+
+.kpi-item.kpi-item-skipped .attribute-tag,
+.kpi-item.kpi-item-skipped .item-note {
+  opacity: 0.6;
+}
+
+.kpi-item.kpi-item-skipped .star {
+  color: #bbb;
+}
+
+.kpi-item.kpi-item-skipped .star.selected {
+  color: #c7c7c7;
+}
+
 .kpi-text {
   flex: 1;
   display: flex;


### PR DESCRIPTION
## Summary
- toggle a CSS class on KPI rows when the exclusion checkbox changes
- introduce muted styling so excluded KPI rows appear greyed out

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd0fd969ac8326a9e44bf080800af5