### PR TITLE
Add simple/advanced KPI toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-const kpiData = [
+const advancedKpiData = [
   {
     heading: '編成中',
     items: [
@@ -114,11 +114,23 @@ const kpiData = [
         ]
       }
 ];
+
+const simpleKpiData = [
+  {
+    heading: 'シンプル項目',
+    items: [
+      { id: 'simple-overview', text: '試合全体の動きに満足できましたか', attributes: ['thinking', 'judgement'] },
+      { id: 'simple-communication', text: '必要なコミュニケーションは取れましたか', attributes: ['teamplay', 'alert'] },
+      { id: 'simple-mechanics', text: 'エイムとアビリティの操作に安定感はありましたか', attributes: ['physical', 'study'] }
+    ]
+  }
+];
 // Build KPI sections including headings while collecting items
 const kpiItems = [];
 const container = document.getElementById('kpi-container');
 const selectionContainer = document.getElementById('selection-container');
 const dropArea = document.getElementById('json-drop-area');
+const complexityToggle = document.getElementById('complexity-toggle');
 let selectedMap = null;
 let selectedAgent = null;
 let loadedDatasets = [];
@@ -518,10 +530,18 @@ function clearKpiContainer() {
   kpiItems.length = 0;
 }
 
+function getActiveKpiData() {
+  if (complexityToggle && complexityToggle.checked) {
+    return advancedKpiData;
+  }
+  return simpleKpiData;
+}
+
 function buildDefaultKpiLayout() {
   if (!container) return;
   clearKpiContainer();
-  kpiData.forEach(section => {
+  const dataset = getActiveKpiData();
+  dataset.forEach(section => {
     const sectionHeading = document.createElement('h2');
     sectionHeading.classList.add('section-heading');
     sectionHeading.textContent = section.heading;
@@ -986,6 +1006,15 @@ document.getElementById('export-btn').addEventListener('click', () => {
 const modeToggle = document.getElementById('mode-toggle');
 const statsPlaceholderValue = 0.0;
 
+if (complexityToggle) {
+  complexityToggle.addEventListener('change', () => {
+    if (!modeToggle || !modeToggle.checked) {
+      buildDefaultKpiLayout();
+      applyMode();
+    }
+  });
+}
+
 function applyMode() {
   const isStatsMode = modeToggle && modeToggle.checked;
   const kpiContainer = document.getElementById('kpi-container');
@@ -1002,6 +1031,10 @@ function applyMode() {
   if (exportBtn) {
     exportBtn.disabled = isStatsMode;
     exportBtn.style.display = isStatsMode ? 'none' : '';
+  }
+
+  if (complexityToggle) {
+    complexityToggle.disabled = isStatsMode;
   }
 
   kpiItems.forEach(item => {

--- a/index.html
+++ b/index.html
@@ -12,6 +12,15 @@
     <p class="github-link"><a href="https://github.com/Nao-Shirotsu/Valoinsight"><img src="assets/github-mark.svg" alt="GitHub" class="github-logo"></a></p>
     <form id="kpi-form">
         <div id="selection-container"></div>
+        <div id="complexity-switch-container">
+            <div id="complexity-switch" class="toggle-switch">
+                <input type="checkbox" id="complexity-toggle">
+                <label for="complexity-toggle" class="toggle-label">
+                    <span class="toggle-simple">シンプル</span>
+                    <span class="toggle-advanced">アドバンスト</span>
+                </label>
+            </div>
+        </div>
         <div id="kpi-container"></div>
     </form>
     <div id="summary-container">

--- a/style.css
+++ b/style.css
@@ -171,6 +171,16 @@ h1 {
   display: none;
 }
 
+#complexity-switch-container {
+  display: flex;
+  justify-content: center;
+  margin: 20px 0 10px;
+}
+
+#complexity-switch {
+  display: inline-flex;
+}
+
 .toggle-label {
   display: flex;
   align-items: center;
@@ -205,6 +215,10 @@ h1 {
   transform: translateX(100%);
 }
 
+#complexity-toggle:checked + .toggle-label::after {
+  transform: translateX(100%);
+}
+
 #mode-toggle:checked + .toggle-label .toggle-grading {
   color: #666;
 }
@@ -219,6 +233,27 @@ h1 {
 
 #mode-toggle:not(:checked) + .toggle-label .toggle-stats {
   color: #666;
+}
+
+#complexity-toggle:checked + .toggle-label .toggle-simple {
+  color: #666;
+}
+
+#complexity-toggle:checked + .toggle-label .toggle-advanced {
+  color: #000;
+}
+
+#complexity-toggle:not(:checked) + .toggle-label .toggle-simple {
+  color: #000;
+}
+
+#complexity-toggle:not(:checked) + .toggle-label .toggle-advanced {
+  color: #666;
+}
+
+.toggle-switch input:disabled + .toggle-label {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 #chart-score-container {


### PR DESCRIPTION
## Summary
- add a simple/advanced toggle below the character selection to switch KPI item sets
- show placeholder simple KPIs by default and restore the full checklist when advanced is selected
- disable the complexity toggle while viewing statistics and style the new control

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd64a0aeb48326a7072dc6debd33b2