### PR TITLE
Update export filename to reflect complexity mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -996,7 +996,8 @@ document.getElementById('export-btn').addEventListener('click', () => {
   a.href = url;
   const mapName = selectedMap ? selectedMap.toLowerCase() : 'unknown';
   const agentName = selectedAgent ? selectedAgent.toLowerCase() : 'unknown';
-  a.download = `valoinsight_${mapName}_${agentName}.json`;
+  const complexityName = complexityToggle && complexityToggle.checked ? 'advanced' : 'simple';
+  a.download = `valoinsight_${complexityName}_${mapName}_${agentName}.json`;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);


### PR DESCRIPTION
## Summary
- include the selected complexity mode in exported JSON filenames so they follow the valoinsight_<complexity>_<map>_<agent>.json pattern

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd68e770fc83269b889638f65de725