### PR TITLE
Update simple mode rating UI

### DIFF
--- a/style.css
+++ b/style.css
@@ -443,6 +443,55 @@ h1 {
   align-self: center;
 }
 
+.simple-rating {
+  display: flex;
+  gap: 8px;
+  align-self: center;
+}
+
+.simple-rating-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 6px 12px;
+  border: 1px solid #cbd5f5;
+  border-radius: 12px;
+  background-color: #f8fafc;
+  color: #1f2937;
+  cursor: pointer;
+  font-size: 0.85em;
+  font-family: inherit;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.simple-rating-option:hover {
+  transform: translateY(-1px);
+  background-color: #eef2ff;
+}
+
+.simple-rating-option.selected {
+  background-color: #dbeafe;
+  border-color: #60a5fa;
+  color: #1d4ed8;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+.simple-rating-option:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+.simple-rating-emoji {
+  font-size: clamp(1.4rem, 1.8vw, 2rem);
+  line-height: 1;
+}
+
+.simple-rating-label {
+  font-size: 0.85em;
+}
+
 .skip-container input[type="checkbox"] {
   transform: scale(1.375);
 }


### PR DESCRIPTION
## Summary
- replace the simple scoring interface with a three-option emoji selector (悪い/普通/良い)
- track ratings as floating-point scores so both advanced and simple modes update averages/export consistently
- style the new simple scoring buttons to match the application's look and feel

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce3669ef208326916e214f7ec38b74