### PR TITLE
Align summary note width with KPI layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -38,13 +38,15 @@ h1 {
   height: var(--heading-font-size);
 }
 
-#kpi-container {
+#kpi-container,
+#summary-container {
   width: 95%;
   margin: 0 auto;
 }
 
 @media (min-width: 1800px) {
-  #kpi-container {
+  #kpi-container,
+  #summary-container {
     width: 55%;
   }
 }
@@ -488,7 +490,6 @@ h1 {
 }
 
 #summary-container {
-  width: 95%;
   margin: 40px auto 120px;
 }
 
@@ -499,7 +500,7 @@ h1 {
   border-radius: 1% / 15%;
   font-size: 1.3rem;
   font-weight: 500;
-  width: 98%;
+  width: 100%;
 }
 
 .summary-label {
@@ -509,12 +510,13 @@ h1 {
 }
 
 .summary-input {
-  width: 98%;
+  width: 100%;
   border: 1px solid #f2f2f8;
   border-radius: 1% / 8%;
   resize: vertical;
   font-family: inherit;
   font-size: 1em;
+  box-sizing: border-box;
 }
 
 #footer {


### PR DESCRIPTION
## Summary
- match the summary note container width to the KPI section across responsive breakpoints
- expand the summary heading and textarea elements to fill the container and maintain padding via box sizing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f6da75508326bbd6b698c4e7b9ca