### PR TITLE
Reposition grading controls above footer

### DIFF
--- a/app.js
+++ b/app.js
@@ -130,6 +130,7 @@ const kpiItems = [];
 const container = document.getElementById('kpi-container');
 const selectionContainer = document.getElementById('selection-container');
 const dropArea = document.getElementById('json-drop-area');
+const dropAreaContainer = dropArea ? dropArea.parentElement : null;
 const complexityToggle = document.getElementById('complexity-toggle');
 let selectedMap = null;
 let selectedAgent = null;
@@ -1028,6 +1029,9 @@ function applyMode() {
   }
   if (dropArea) {
     dropArea.style.display = isStatsMode ? '' : 'none';
+  }
+  if (dropAreaContainer) {
+    dropAreaContainer.style.display = isStatsMode ? 'flex' : 'none';
   }
   if (exportBtn) {
     exportBtn.disabled = isStatsMode;

--- a/index.html
+++ b/index.html
@@ -21,6 +21,18 @@
                 </label>
             </div>
         </div>
+        <div id="mode-switch-container">
+            <div id="mode-switch" class="toggle-switch">
+                <input type="checkbox" id="mode-toggle">
+                <label for="mode-toggle" class="toggle-label">
+                    <span class="toggle-grading">採点</span>
+                    <span class="toggle-stats">統計</span>
+                </label>
+            </div>
+        </div>
+        <div id="drop-area-container">
+            <div id="json-drop-area" class="drop-area" style="display:none;">採点ファイルをここにドラッグ＆ドロップ(複数可)</div>
+        </div>
         <div id="kpi-container"></div>
     </form>
     <div id="summary-container">
@@ -31,6 +43,9 @@
         <textarea id="summary-bad" class="summary-input"></textarea>
         <label for="summary-focus" class="summary-label">重点的に伸ばすべき要素は何でしたか</label>
         <textarea id="summary-focus" class="summary-input"></textarea>
+        <div id="export-container">
+            <button id="export-btn">ファイルに保存</button>
+        </div>
     </div>
     <div id="average-container">
         <div id="chart-score-container">
@@ -64,20 +79,6 @@
                 </div>
             </div>
         </div>
-        <div id="controls-container">
-            <div id="mode-switch" class="toggle-switch">
-                <input type="checkbox" id="mode-toggle">
-                <label for="mode-toggle" class="toggle-label">
-                    <span class="toggle-grading">採点</span>
-                    <span class="toggle-stats">統計</span>
-                </label>
-            </div>
-            <div id="file-controls">
-                <button id="export-btn">ファイルに保存</button>
-                <div id="json-drop-area" class="drop-area" style="display:none;">採点ファイルをここにドラッグ＆ドロップ(複数可)</div>
-            </div>
-        </div>
-    </div>
     </div>
     <div id="footer">
         <br><br><br>

--- a/style.css
+++ b/style.css
@@ -50,15 +50,15 @@ h1 {
 }
 
 #json-drop-area {
-  width: 12vw;
-  height: 6vw;
-  min-width: 150px;
-  padding: 20px 10px;
+  width: 18vw;
+  height: 9vw;
+  min-width: 225px;
+  padding: 30px 15px;
   border: 2px dashed #bbb;
   text-align: center;
   color: #666;
   background-color: #fafafa;
-  font-size: 1.25vw;
+  font-size: 1.875vw;
 }
 
 #json-drop-area.dragover {
@@ -148,25 +148,6 @@ h1 {
   align-items: center;
   justify-content: center;
 }
-#controls-container {
-  position: absolute;
-  right: 0;
-  top: 10%;
-  margin-right: 3%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-}
-/* mode switch positioned via controls-container */
-#mode-switch {}
-
-#file-controls {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
 .toggle-switch input {
   display: none;
 }
@@ -179,6 +160,18 @@ h1 {
 
 #complexity-switch {
   display: inline-flex;
+}
+
+#mode-switch-container {
+  display: flex;
+  justify-content: center;
+  margin: 0 0 20px;
+}
+
+#drop-area-container {
+  display: none;
+  justify-content: center;
+  margin-bottom: 20px;
 }
 
 .toggle-label {
@@ -194,6 +187,13 @@ h1 {
 }
 
 #complexity-switch .toggle-label {
+  width: 225px;
+  height: 48px;
+  border-radius: 24px;
+  font-size: 1.25rem;
+}
+
+#mode-switch .toggle-label {
   width: 225px;
   height: 48px;
   border-radius: 24px;
@@ -336,13 +336,20 @@ h1 {
   background-color: var(--color-study);
 }
 
+
 .attribute-label {
   width: 6em;
 }
 
+#export-container {
+  display: flex;
+  justify-content: center;
+  margin: 24px 0 0;
+}
+
 #export-btn {
-  padding: 6px 12px;
-  font-size: 1rem;
+  padding: 9px 18px;
+  font-size: 1.5rem;
 }
 
 #export-btn:disabled {


### PR DESCRIPTION
## Summary
- move the grading/statistics toggle below the agent selection divider to match the complexity switch styling
- relocate the export button beneath the summary notes and resize the statistics drop area for easier access
- update mode switching logic to show or hide the relocated controls appropriately

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f683bb488326b10d82118cb84ef4