### PR TITLE
Ensure KPI footer stays fixed to viewport bottom

### DIFF
--- a/style.css
+++ b/style.css
@@ -138,9 +138,10 @@ h1 {
 }
 
 #average-container {
-  position: sticky;
+  position: fixed;
   bottom: 0;
   left: 0;
+  right: 0;
   width: 100%;
   background-color: #fff;
   padding: 16px 10px;


### PR DESCRIPTION
## Summary
- switch the average score footer from sticky to fixed positioning so it remains attached to the viewport bottom

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8056707a883269ed5266ae4e7e7a7